### PR TITLE
Disable iscsi sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,12 @@ This CSI driver is an open-source project under the Apache 2.0 [license](./LICEN
 `iscsid` and `multipathd` must be installed on every node. Check the installation method appropriate for your Linux distribution.
 #### Ubuntu installation procedure
 - Install required packages:
+```
     sudo apt update && sudo apt install open-iscsi scsitools multipath-tools
+```
 - Install packages for the required filesystem (ext3/ext4/xfs)
 - Update /etc/multipath.conf with the following lines:
+```
     defaults {
       polling_interval 2
       find_multipaths "yes"
@@ -59,9 +62,11 @@ This CSI driver is an open-source project under the Apache 2.0 [license](./LICEN
             no_path_retry 18
             }
     }
+```
 - Restart MultipathD
+```
     service multipath-tools restart
-
+```
 
 ### Deploy the provisioner to your kubernetes cluster
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,39 @@ This CSI driver is an open-source project under the Apache 2.0 [license](./LICEN
 
 ## Installation
 
-### Uninstall ISCSI tools on your node(s)
+### Install ISCSI tools and Multipath driver on your node(s)
 
-`iscsid` and `multipathd` are now shipped as sidecars on each nodes, it is therefore strongly suggested to uninstall any `open-iscsi` and `multipath-tools` package.
+`iscsid` and `multipathd` must be installed on every node. Check the installation method appropriate for your Linux distribution.
+#### Ubuntu installation procedure
+- Install required packages:
+    sudo apt update && sudo apt install open-iscsi scsitools multipath-tools
+- Install packages for the required filesystem (ext3/ext4/xfs)
+- Update /etc/multipath.conf with the following lines:
+    defaults {
+      polling_interval 2
+      find_multipaths "yes"
+      retain_attached_hw_handler "no"
+      disable_changed_wwids "yes"
+    }
+    devices {
+            device {
+            vendor "HP"
+            product "MSA 2040 SAN"
+            path_grouping_policy group_by_prio
+            getuid_callout "/lib/udev/scsi_id --whitelisted --device=/dev/%n"
+            prio alua
+            path_selector "round-robin 0"
+            path_checker tur
+            hardware_handler "0"
+           failback immediate
+            rr_weight uniform
+            rr_min_io_rq 1
+            no_path_retry 18
+            }
+    }
+- Restart MultipathD
+    service multipath-tools restart
 
-The decision of shipping `iscsid` and `multipathd` as sidecars comes from the desire to simplify the developpement process, as well as improving monitoring. It's essential that versions of those softwares match the candidates versions on your hosts, more about this in the [FAQ](./docs/troubleshooting.md#multipathd-segfault-or-a-volume-got-corrupted). This setup is currently being challenged.
 
 ### Deploy the provisioner to your kubernetes cluster
 

--- a/helm/csi-charts/templates/daemonset.yaml
+++ b/helm/csi-charts/templates/daemonset.yaml
@@ -29,23 +29,6 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeServer.nodeSelector | indent 8 }}
       {{- end }}
-      initContainers:
-        - name: init-iscsi
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
-          command:
-            - /usr/local/bin/init-node.sh
-          securityContext:
-            capabilities:
-              add:
-                - SYS_MODULE
-          volumeMounts:
-            - name: iscsi-dir
-              mountPath: /host/iscsi
-            - name: kernel-modules
-              mountPath: /lib/modules
-            - name: init-node
-              mountPath: /usr/local/bin/init-node.sh
-              subPath: init-node.sh
       containers:
         - name: seagate-csi-node
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
@@ -80,42 +63,6 @@ spec:
               path: /healthz
               port: healthz
             periodSeconds: 60
-        - name: iscsid
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
-          command:
-            - iscsid
-            - --foreground
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: device-dir
-              mountPath: /dev
-            - name: iscsi-dir
-              mountPath: /etc/iscsi
-            - name: plugin-dir
-              mountPath: {{ .Values.kubeletPath }}/plugins/systems.csi.seagate.io
-            - name: mountpoint-dir
-              mountPath: {{ .Values.kubeletPath }}/pods
-              mountPropagation: Bidirectional
-        - name: multipathd
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
-          command:
-            - multipathd
-            - -d
-            - -s
-{{- include "csidriver.extraArgs" .Values.multipathd | indent 10 }}
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: device-dir
-              mountPath: /dev
-            - name: init-node
-              mountPath: /etc/multipath.conf
-              subPath: multipath.conf
-            - name: multipath-dir
-              mountPath: /etc/multipath
-            - name: udev-dir
-              mountPath: /run/udev
         - name: liveness-probe
           image: {{.Values.nodeLivenessProbe.image.repository }}:{{ .Values.nodeLivenessProbe.image.tag }}
           args:


### PR DESCRIPTION
This PR removes deployment of iscsi and multipath sidecars and updates README with the steps required to install iscsid and multipath-tools on every node

-----
[View rendered README.md](https://github.com/gregnsk/seagate-exos-x-csi/blob/disable-iscsi-sidecar/README.md)