### PR TITLE
v0.5.4 storing devicePath, checking dependencies, and setting Multipa…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
+.PHONY: help all bin controller node test image limage ubi push clean
+
 ifndef DOCKER_HUB_REPOSITORY
 	DOCKER_HUB_REPOSITORY = ghcr.io/seagate
 endif
 
 ifndef VERSION
-	VERSION = v0.5.3
+	VERSION = v0.5.4
 endif
 
 VERSION_FLAG = -X github.com/Seagate/seagate-exos-x-csi/pkg/common.Version=$(VERSION)
@@ -19,7 +21,7 @@ help:
 	@echo "Build Targets:"
 	@echo "-----------------------------------------------------------------------------------"
 	@echo "make clean      - remove '$(BIN)-controller' and '$(BIN)-node'"
-	@echo "make all        - create controller and node driver images, create docker image"
+	@echo "make all        - clean, create driver images, create ubi docker image, push to registry"
 	@echo "make bin        - create controller and node driver images"
 	@echo "make controller - create controller driver image ($(BIN)-controller)"
 	@echo "make node       - create node driver image ($(BIN)-node)"
@@ -30,40 +32,46 @@ help:
 	@echo "make push       - push the docker image to '$(DOCKER_HUB_REPOSITORY)'"
 	@echo ""
 
-all:		bin limage
-.PHONY: all
+all: clean bin ubi push
 
 bin: controller node
-.PHONY: bin
 
 controller:
+	@echo ""
+	@echo "[] controller"
 	go build -v -ldflags "$(VERSION_FLAG)" -o $(BIN)-controller ./cmd/controller
-.PHONY: controller
 
 node:
+	@echo ""
+	@echo "[] node"
 	go build -v -ldflags "$(VERSION_FLAG)" -o $(BIN)-node ./cmd/node
-.PHONY: node
 
 test:
+	@echo ""
+	@echo "[] test"
 	./test/sanity
-.PHONY: test
 
 image:
+	@echo ""
+	@echo "[] image"
 	docker build -t $(IMAGE) --build-arg version="$(VERSION)" --build-arg vcs_ref="$(shell git rev-parse HEAD)" --build-arg build_date="$(shell date --rfc-3339=seconds)" .
-.PHONY: image
 
 limage:
+	@echo ""
+	@echo "[] limage"
 	docker build -f Dockerfile.local -t $(IMAGE) --build-arg version="$(VERSION)" --build-arg vcs_ref="$(shell git rev-parse HEAD)" --build-arg build_date="$(shell date --rfc-3339=seconds)" .
-.PHONY: limage
 
 ubi:
+	@echo ""
+	@echo "[] ubi"
 	docker build -f Dockerfile.ubi -t $(IMAGE) --build-arg version="$(VERSION)" --build-arg vcs_ref="$(shell git rev-parse HEAD)" --build-arg build_date="$(shell date --rfc-3339=seconds)" .
-.PHONY: limage
 
 push:
+	@echo ""
+	@echo "[] push"
 	docker push $(IMAGE)
-.PHONY: push
 
 clean:
+	@echo ""
+	@echo "[] clean"
 	rm -vf $(BIN)-controller $(BIN)-node
-.PHONY: clean

--- a/helm/csi-charts/Chart.yaml
+++ b/helm/csi-charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: csi-driver
-version: 0.5.3
-appVersion: 0.5.3
+version: 0.5.4
+appVersion: 0.5.4
 description: A dynamic persistent volume (PV) provisioner for Seagate Exos X storage systems.
 type: application
 home: https://github.com/Seagate/seagate-exos-x-csi

--- a/helm/csi-charts/values.yaml
+++ b/helm/csi-charts/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/seagate/seagate-exos-x-csi
   # -- Tag to use for nodes and controller
   # @default -- Uses Chart.appVersion value by default if tag does not specify a new version.
-  tag: "v0.5.3"
+  tag: "v0.5.4"
   # -- Default is set to IfNotPresent, to override use Always here to always pull the specified version
   pullPolicy: Always
 


### PR DESCRIPTION
- Version 0.5.4
- Additional iSCSI debug
- Correction to multipath to list /sys/blocks/dm-*/slaves
- Correction to multipath to not add on an additional '/dev' prefix
- iscsi: checking devicePath == "", storing devicePath, and setting Multipath to true
- Complete demo and cleanup working