### PR TITLE
v0.5.5 updates to use older blkid options for compatibility reasons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 .PHONY: help all bin controller node test image limage ubi push clean
 
-ifndef DOCKER_HUB_REPOSITORY
-	DOCKER_HUB_REPOSITORY = ghcr.io/seagate
+ifdef DOCKER_HUB_REPOSITORY
+DOCKER_HUB_REPOSITORY := $(DOCKER_HUB_REPOSITORY)
+else
+DOCKER_HUB_REPOSITORY := ghcr.io/seagate
 endif
 
-ifndef VERSION
-	VERSION = v0.5.4
+ifdef VERSION
+VERSION := $(VERSION)
+else
+VERSION := v0.5.5
 endif
 
 VERSION_FLAG = -X github.com/Seagate/seagate-exos-x-csi/pkg/common.Version=$(VERSION)

--- a/helm/csi-charts/Chart.yaml
+++ b/helm/csi-charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: csi-driver
-version: 0.5.4
-appVersion: 0.5.4
+version: 0.5.5
+appVersion: 0.5.5
 description: A dynamic persistent volume (PV) provisioner for Seagate Exos X storage systems.
 type: application
 home: https://github.com/Seagate/seagate-exos-x-csi

--- a/helm/csi-charts/values.yaml
+++ b/helm/csi-charts/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/seagate/seagate-exos-x-csi
   # -- Tag to use for nodes and controller
   # @default -- Uses Chart.appVersion value by default if tag does not specify a new version.
-  tag: "v0.5.4"
+  tag: "v0.5.5"
   # -- Default is set to IfNotPresent, to override use Always here to always pull the specified version
   pullPolicy: Always
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -379,10 +379,10 @@ func findDeviceFormat(device string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	output, err := exec.CommandContext(ctx, "blkid",
-		"--probe",
-		"--match-tag", "TYPE",
-		"--match-tag", "PTTYPE",
-		"--output", "export",
+		"-p",
+		"-s", "TYPE",
+		"-s", "PTTYPE",
+		"-o", "export",
 		device).CombinedOutput()
 
 	if ctx.Err() == context.DeadlineExceeded {


### PR DESCRIPTION
- Version 0.5.5
- Changed blkid to use single dash switches which are supported in older and new versions
- Corrected the Makefile to work with env variables.