### PR TITLE
v0.6.0 Discover iSCSI IQN and Portals from storage appliance, not req…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 ifdef VERSION
 VERSION := $(VERSION)
 else
-VERSION := v0.5.6
+VERSION := v0.6.0
 endif
 
 VERSION_FLAG = -X github.com/Seagate/seagate-exos-x-csi/pkg/common.Version=$(VERSION)

--- a/docs/iscsi/storage-class.yaml
+++ b/docs/iscsi/storage-class.yaml
@@ -12,7 +12,5 @@ parameters:
   csi.storage.k8s.io/controller-expand-secret-name: secret-seagate
   csi.storage.k8s.io/controller-expand-secret-namespace: seagate
   fsType: ext4 # Desired filesystem
-  iqn: iqn.1992-09.com.seagate:01.array.00c0ff0afca8
   pool: A # Pool for volumes provisioning
-  portals: 172.9.1.22,172.9.1.23
   volPrefix: stx # Desired prefix for volume naming, an underscore is appended

--- a/example/storage-class.yaml
+++ b/example/storage-class.yaml
@@ -14,6 +14,4 @@ parameters:
   csi.storage.k8s.io/controller-expand-secret-name: seagate-exos-x-csi-secrets
   csi.storage.k8s.io/controller-expand-secret-namespace: default
   fsType: ext4 # Desired filesystem
-  iqn: iqn.2015-11.com.hpe:storage.msa2040.163639c929 # Gallium 10.235.212.197 Appliance IQN
   pool: A # Pool to use on the IQN to provision volumes
-  portals: 10.235.212.199,10.235.212.200 # Comma separated list of portal ips. Gallium 10.235.212.197 Ports A1, B1

--- a/example/storageclass-example1.yaml
+++ b/example/storageclass-example1.yaml
@@ -14,7 +14,5 @@ parameters:
   csi.storage.k8s.io/controller-expand-secret-name: seagate-exos-x-csi-secrets
   csi.storage.k8s.io/controller-expand-secret-namespace: default
   fsType: ext4 # Desired filesystem
-  iqn: <iqn> # Example Appliance IQN
   pool: A # Pool to use on the IQN to provision volumes
-  portals: <ipaddress-a1>,<ipaddress-b1> # Comma separated list of portal ips. Ports A1, B1
   volPrefix: csi # Desired prefix for volume naming, an underscore is appended

--- a/helm/csi-charts/values.yaml
+++ b/helm/csi-charts/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/seagate/seagate-exos-x-csi
   # -- Tag to use for nodes and controller
   # @default -- Uses Chart.appVersion value by default if tag does not specify a new version.
-  tag: "v0.5.6"
+  tag: "v0.6.0"
   # -- Default is set to IfNotPresent, to override use Always here to always pull the specified version
   pullPolicy: Always
 

--- a/pkg/common/driver.go
+++ b/pkg/common/driver.go
@@ -25,7 +25,6 @@ const PluginName = "csi-exos-x.seagate.com"
 const (
 	FsTypeConfigKey           = "fsType"
 	PoolConfigKey             = "pool"
-	TargetIQNConfigKey        = "iqn"
 	PortalsConfigKey          = "portals"
 	APIAddressConfigKey       = "apiAddress"
 	UsernameSecretKey         = "username"

--- a/pkg/common/driver.go
+++ b/pkg/common/driver.go
@@ -25,7 +25,6 @@ const PluginName = "csi-exos-x.seagate.com"
 const (
 	FsTypeConfigKey           = "fsType"
 	PoolConfigKey             = "pool"
-	PortalsConfigKey          = "portals"
 	APIAddressConfigKey       = "apiAddress"
 	UsernameSecretKey         = "username"
 	PasswordSecretKey         = "password"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -259,12 +259,6 @@ func runPreflightChecks(parameters *map[string]string, capabilities *[]*csi.Volu
 	if err := checkIfKeyExistsInConfig(common.PoolConfigKey); err != nil {
 		return err
 	}
-	if err := checkIfKeyExistsInConfig(common.TargetIQNConfigKey); err != nil {
-		return err
-	}
-	if err := checkIfKeyExistsInConfig(common.PortalsConfigKey); err != nil {
-		return err
-	}
 
 	if capabilities != nil {
 		if len(*capabilities) == 0 {

--- a/pkg/controller/provisioner.go
+++ b/pkg/controller/provisioner.go
@@ -63,6 +63,12 @@ func (controller *Controller) CreateVolume(ctx context.Context, req *csi.CreateV
 		}
 	}
 
+	// Fill iSCSI context parameters
+	targetid, _ := controller.client.Info.GetTargetId()
+	req.GetParameters()["iqn"] = targetid
+	portals, _ := controller.client.Info.GetPortals()
+	req.GetParameters()["portals"] = portals
+
 	volume := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:      volumeID,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -146,8 +146,9 @@ func (node *Node) NodePublishVolume(ctx context.Context, req *csi.NodePublishVol
 
 	klog.Infof("publishing volume %s", req.GetVolumeId())
 
-	portals := strings.Split(req.GetVolumeContext()[common.PortalsConfigKey], ",")
-	klog.Infof("ISCSI portals: %s", portals)
+	iqn := req.GetVolumeContext()["iqn"]
+	portals := strings.Split(req.GetVolumeContext()["portals"], ",")
+	klog.Infof("iSCSI iqn: %s, portals: %v", iqn, portals)
 
 	lun, _ := strconv.ParseInt(req.GetPublishContext()["lun"], 10, 32)
 	klog.Infof("LUN: %d", lun)
@@ -156,7 +157,7 @@ func (node *Node) NodePublishVolume(ctx context.Context, req *csi.NodePublishVol
 	targets := make([]iscsi.TargetInfo, 0)
 	for _, portal := range portals {
 		targets = append(targets, iscsi.TargetInfo{
-			Iqn:    req.GetVolumeContext()[common.TargetIQNConfigKey],
+			Iqn:    iqn,
 			Portal: portal,
 		})
 	}

--- a/test/config.yml
+++ b/test/config.yml
@@ -1,4 +1,2 @@
 pool: B
 fsType: ext4
-iqn: iqn.2015-11.com.hpe:storage.msa2050.18323cc9ed
-portals: 10.14.84.211,10.14.84.212

--- a/test/csc
+++ b/test/csc
@@ -4,8 +4,6 @@ csc=$(which csc)
 
 fsType="ext4"
 pool="B"
-iqn="iqn.2015-11.com.hpe:storage.msa2050.18323cc9ed"
-portals="10.14.84.211,10.14.84.212"
 
 function setup {
 	cd $(dirname $0)
@@ -14,4 +12,4 @@ function setup {
 }
 
 setup
-${csc} --params "fsType=${fsType},pool=${pool},iqn=${iqn},portals=${portals}" $@
+${csc} --params "fsType=${fsType},pool=${pool}" $@


### PR DESCRIPTION
- Version 0.6.0
- For iSCSI, the IQN and IP Address portals are determined from the storage appliance
- StorageClass parameters 'iqn' and 'portals' are no longer required
