### PR TITLE
fix: code adjustments to pass csi-sanity ListSnapshots tests

### DIFF
--- a/pkg/common/driver.go
+++ b/pkg/common/driver.go
@@ -51,7 +51,7 @@ type WithSecrets interface {
 
 // WithParameters is an interface for structs with parameters
 type WithParameters interface {
-	GetParameters() *map[string]string
+	GetParameters() map[string]string
 }
 
 // WithVolumeCaps is an interface for structs with volume capabilities

--- a/pkg/common/system.go
+++ b/pkg/common/system.go
@@ -44,6 +44,7 @@ func ValidateName(s string) bool {
 // TranslateName converts the passed in volume name to the translated volume name
 func TranslateName(name, prefix string) (string, error) {
 
+	klog.V(2).Infof("TranslateName VolumeNameMaxLength=%d name=[%d]%q prefix=[%d]%q", VolumeNameMaxLength, len(name), name, len(prefix), prefix)
 	volumeID := name
 
 	if len(prefix) == 0 {
@@ -58,7 +59,10 @@ func TranslateName(name, prefix string) (string, error) {
 				volumeID = volumeID[9:]
 			}
 			volumeID = strings.ReplaceAll(volumeID, "-", "")
-			volumeID = volumeID[:VolumeNameMaxLength]
+			klog.V(2).Infof("volumeID=[%d]%q", len(volumeID), volumeID)
+			if len(volumeID) > VolumeNameMaxLength {
+				volumeID = volumeID[:VolumeNameMaxLength]
+			}
 		}
 	} else {
 		// Skip over 'pvc-' and remove all dashes

--- a/test/sanity-cli
+++ b/test/sanity-cli
@@ -1,7 +1,25 @@
 #! /usr/bin/env bash
 
+#
+# Usage: sanity-cli [all]
+#
+# Running ./sanity-cli
+#     Will fail fast (-ginkgo.failFast) and use -ginkgo.focus based on TEST_FOCUS
+#     Use `export TEST_FOCUS=<item>`, such as <item> = CreateVolume to limit test cases
+#
+# Running ./sanity-cli all
+#     Will run all test cases and continue past failures
+#
+
+if [ -z ${1+x} ]; then
+    opt=
+else
+    opt=$1
+fi
+
 echo ""
-echo "[] sanity-cli"
+echo "[] sanity-cli $opt"
+
 
 secretsTemplate="secrets.template.yml"
 secrets="secrets.yml"
@@ -60,12 +78,19 @@ setup
 controller=unix:///var/run/csi-exos-x.seagate.com/csi-controller.sock
 node=unix:///var/run/csi-exos-x.seagate.com/csi-node.sock
 sanity=/home/seagate/github.com/kubernetes-csi/csi-test/cmd/csi-sanity/csi-sanity
+# sanity=/home/seagate/github.com/jskazinski/csi-test/cmd/csi-sanity/csi-sanity
 focus=${test_focus}
 
 echo ""
 echo "[] csi-sanity"
-echo "sudo ${sanity} -csi.controllerendpoint ${controller} -csi.endpoint ${node} -csi.secrets ${secrets} -ginkgo.focus \"${focus}\" -csi.testvolumeparameters ${volume} -ginkgo.failFast > sanity.log"
-sudo ${sanity} -csi.controllerendpoint ${controller} -csi.endpoint ${node} -csi.secrets ${secrets} -ginkgo.focus "${focus}" -csi.testvolumeparameters ${volume} -ginkgo.failFast > sanity.log 
+
+if [ "$opt" == "all" ]; then
+    echo "sudo ${sanity} -csi.controllerendpoint ${controller} -csi.endpoint ${node} -csi.secrets ${secrets} -csi.testvolumeparameters ${volume} > sanity.log"
+    sudo ${sanity} -csi.controllerendpoint ${controller} -csi.endpoint ${node} -csi.secrets ${secrets} -csi.testvolumeparameters ${volume} > sanity.log 
+else
+    echo "sudo ${sanity} -csi.controllerendpoint ${controller} -csi.endpoint ${node} -csi.secrets ${secrets} -ginkgo.focus \"${focus}\" -csi.testvolumeparameters ${volume} -ginkgo.failFast > sanity.log"
+    sudo ${sanity} -csi.controllerendpoint ${controller} -csi.endpoint ${node} -csi.secrets ${secrets} -ginkgo.focus "${focus}" -csi.testvolumeparameters ${volume} -ginkgo.failFast > sanity.log 
+fi
 
 out=$?
 

--- a/test/secrets.template.yml
+++ b/test/secrets.template.yml
@@ -1,3 +1,36 @@
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+# // CSISecrets consists of secrets used in CSI credentials.
+# type CSISecrets struct {
+# 	CreateVolumeSecret                         map[string]string `yaml:"CreateVolumeSecret"`
+# 	DeleteVolumeSecret                         map[string]string `yaml:"DeleteVolumeSecret"`
+# 	ControllerPublishVolumeSecret              map[string]string `yaml:"ControllerPublishVolumeSecret"`
+# 	ControllerUnpublishVolumeSecret            map[string]string `yaml:"ControllerUnpublishVolumeSecret"`
+# 	ControllerValidateVolumeCapabilitiesSecret map[string]string `yaml:"ControllerValidateVolumeCapabilitiesSecret"`
+# 	NodeStageVolumeSecret                      map[string]string `yaml:"NodeStageVolumeSecret"`
+# 	NodePublishVolumeSecret                    map[string]string `yaml:"NodePublishVolumeSecret"`
+# 	CreateSnapshotSecret                       map[string]string `yaml:"CreateSnapshotSecret"`
+# 	DeleteSnapshotSecret                       map[string]string `yaml:"DeleteSnapshotSecret"`
+# 	ControllerExpandVolumeSecret               map[string]string `yaml:"ControllerExpandVolumeSecret"`
+# 	ListSnapshotsSecret                        map[string]string `yaml:"ListSnapshotsSecret"`
+# }
+
 CreateVolumeSecret:
   username: $TEST_USERNAME
   password: $TEST_PASSWORD
@@ -14,15 +47,15 @@ ControllerUnpublishVolumeSecret:
   username: $TEST_USERNAME
   password: $TEST_PASSWORD
   apiAddress: $TEST_IP
+ControllerValidateVolumeCapabilitiesSecret:
+  username: $TEST_USERNAME
+  password: $TEST_PASSWORD
+  apiAddress: $TEST_IP
 NodeStageVolumeSecret:
   username: $TEST_USERNAME
   password: $TEST_PASSWORD
   apiAddress: $TEST_IP
 NodePublishVolumeSecret:
-  username: $TEST_USERNAME
-  password: $TEST_PASSWORD
-  apiAddress: $TEST_IP
-ControllerValidateVolumeCapabilitiesSecret:
   username: $TEST_USERNAME
   password: $TEST_PASSWORD
   apiAddress: $TEST_IP
@@ -35,6 +68,10 @@ DeleteSnapshotSecret:
   password: $TEST_PASSWORD
   apiAddress: $TEST_IP
 ControllerExpandVolumeSecret:
+  username: $TEST_USERNAME
+  password: $TEST_PASSWORD
+  apiAddress: $TEST_IP
+ListSnapshotsSecret:
   username: $TEST_USERNAME
   password: $TEST_PASSWORD
   apiAddress: $TEST_IP


### PR DESCRIPTION
- Correction to GetParamerers to allocate a map object, not a pointer to a map object
- Correction made to properly handle TranslateName(), which takes a CO volume/snapshot name and modifies it to work with exos-x storage
- Updated the csi-sanity template to include ListSnapshotSecrets
- Updated sanity-cli to all a parameter of "all" which will ignore -ginko.focus and run all tests
- Corrections to NodeUnpublishVolume to conform to CSI rpc specification
- Corrections to NodeExpandVolume to conform to CSI rpc specification
- Corrections to ListSnapshots to conform to CSI rpc specification