### PR TITLE
fix: Corrected Controller CreateVolume to use default iscsi when stor…

### DIFF
--- a/pkg/controller/provisioner.go
+++ b/pkg/controller/provisioner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Seagate/seagate-exos-x-csi/pkg/common"
+	"github.com/Seagate/seagate-exos-x-csi/pkg/storage"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -32,13 +33,7 @@ func (controller *Controller) CreateVolume(ctx context.Context, req *csi.CreateV
 	}
 
 	// Extract the storage interface protocol to be used for this volume (iscsi, fc, sas, etc)
-	storageProtocol := parameters[common.StorageProtocolKey]
-
-	if storageProtocol == "" {
-		klog.Warningf("Invalid or no storage protocol specified (%s)", storageProtocol)
-		klog.Warningf("Expecting storageProtocol (iscsi, fc, sas, etc) in StorageClass YAML. Default of (%s) used.", common.StorageProtocolISCSI)
-		storageProtocol = common.StorageProtocolISCSI
-	}
+	storageProtocol := storage.ValidateStorageProtocol(parameters[common.StorageProtocolKey])
 
 	if common.ValidateName(volumeName) == false {
 		return nil, status.Error(codes.InvalidArgument, "volume name contains invalid characters")

--- a/pkg/storage/storageService.go
+++ b/pkg/storage/storageService.go
@@ -76,3 +76,14 @@ func NewStorageNode(storageProtocol string, config map[string]string) (StorageOp
 	}
 	return nil, err
 }
+
+// ValidateStorageProtocol: Verifies that a correct protocol is chosen or returns a valid default storage protocol.
+func ValidateStorageProtocol(storageProtocol string) string {
+	if storageProtocol == common.StorageProtocolFC || storageProtocol == common.StorageProtocolISCSI || storageProtocol == common.StorageProtocolSAS {
+		return storageProtocol
+	} else {
+		klog.Warningf("Invalid or no storage protocol specified (%s)", storageProtocol)
+		klog.Warningf("Expecting storageProtocol (iscsi, fc, sas, etc) in StorageClass YAML. Default of (%s) used.", common.StorageProtocolISCSI)
+		return common.StorageProtocolISCSI
+	}
+}


### PR DESCRIPTION
Corrected Controller CreateVolume to handle the case where the storageProtocol is NOT specified in the StorageClass YAML file. The default of iscsi is used when the user does not specify a storage protocol. Additional debug was also added when the controller code is attempting to retrieve the iSCSI IQN and portals and there is an error.
