### PR TITLE
fix: mutex protection, wwn for multipath confirmation

### DIFF
--- a/example/monitor-pvc-hell.sh
+++ b/example/monitor-pvc-hell.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+lastpodcount=0
+lastpending=0
+lastinit=0
+lastrunning=0
+lastcompleted=0
+lastiniterror=0
+lastpvcs_count=0
+lastpvcs_pending=0
+lastpvcs_bound=0
+lastpvcs_failed=0
+lastpvcs_terminating=0
+lastpvs_count=0
+lastpvs_bound=0
+lastpvs_released=0
+
+doprint=0
+skipped=0
+
+function update()
+{
+    doprint=0
+
+    pods="$(kubectl get pod -A 2> /dev/null | grep "pod-" | sed '/^\s*$/d')"
+    podcount=$(echo -n "$pods" | grep -c '^')
+    pending=$(echo -n "$pods" | grep Pending | grep -c '^')
+    init=$(echo -n "$pods" | grep Init:0 | grep -c '^')
+    running=$(echo -n "$pods" | grep Running | grep -c '^')
+    completed=$(echo -n "$pods" | grep Completed | grep -c '^')
+    initerror=$(echo -n "$pods" | grep Init:Error | grep -c '^')
+
+    pvcs="$(kubectl get pvc -A 2> /dev/null | grep "my-marvelous-storage" | sed '/^\s*$/d')"
+    pvcs_count=$(echo -n "$pvcs" | grep -c '^')
+    pvcs_pending=$(echo -n "$pvcs" | grep Pending | grep -c '^')
+    pvcs_bound=$(echo -n "$pvcs" | grep Bound | grep -c '^')
+    pvcs_failed=$(echo -n "$pvcs" | grep Failed | grep -c '^')
+    pvcs_terminating=$(echo -n "$pvcs" | grep Terminating | grep -c '^')
+
+    pvs="$(kubectl get pv -A 2> /dev/null | grep "my-marvelous-storage" | sed '/^\s*$/d')"
+    pvs_count=$(echo -n "$pvs" | grep -c '^')
+    pvs_bound=$(echo -n "$pvs" | grep Bound | grep -c '^')
+    pvs_released=$(echo -n "$pvs" | grep Released | grep -c '^')
+
+    # PODs
+    if [ "$lastpodcount" != "$podcount" ]; then
+        lastpodcount=$podcount
+        doprint=1
+    fi
+    if [ "$lastpending" != "$pending" ]; then
+        lastpending=$pending
+        doprint=1
+    fi
+    if [ "$lastinit" != "$init" ]; then
+        lastinit=$init
+        doprint=1
+    fi
+    if [ "$lastrunning" != "$running" ]; then
+        lastrunning=$running
+        doprint=1
+    fi
+    if [ "$lastcompleted" != "$completed" ]; then
+        lastcompleted=$completed
+        doprint=1
+    fi
+    if [ "$lastiniterror" != "$initerror" ]; then
+        lastiniterror=$initerror
+        doprint=1
+    fi
+
+    # PVCs
+    if [ "$lastpvcs_count" != "$pvcs_count" ]; then
+        lastpvcs_count=$pvcs_count
+        doprint=1
+    fi
+    if [ "$lastpvcs_pending" != "$pvcs_pending" ]; then
+        lastpvcs_pending=$pvcs_pending
+        doprint=1
+    fi
+    if [ "$lastpvcs_bound" != "$pvcs_bound" ]; then
+        lastpvcs_bound=$pvcs_bound
+        doprint=1
+    fi
+    if [ "$lastpvcs_failed" != "$pvcs_failed" ]; then
+        lastpvcs_failed=$pvcs_failed
+        doprint=1
+    fi
+    if [ "$lastpvcs_terminating" != "$pvcs_terminating" ]; then
+        lastpvcs_terminating=$pvcs_terminating
+        doprint=1
+    fi
+
+    # PVs
+    if [ "$lastpvs_count" != "$pvs_count" ]; then
+        lastpvs_count=$pvs_count
+        doprint=1
+    fi
+    if [ "$lastpvs_bound" != "$pvs_bound" ]; then
+        lastpvs_bound=$pvs_bound
+        doprint=1
+    fi
+    if [ "$lastpvs_released" != "$pvs_released" ]; then
+        lastpvs_released=$pvs_released
+        doprint=1
+    fi
+}
+
+function printupdate()
+{
+    if [ "$doprint" -eq "1" ]; then
+        if [ "$skipped" -eq "1" ]; then
+            printf "\n"
+            skipped=0
+        fi
+        printf "$(date) 🔹 "
+        printf "Pods: % 4d (% 4d ⏳️, % 4d init, % 4d 🏃, % 4d ✅, % 4d initerror)" $podcount $pending $init $running $completed $initerror
+        printf " 🔹 PVCs: % 4d (% 4d ⏳️, % 4d bound, % 4d 💥, % 4d terminating)" $pvcs_count $pvcs_pending $pvcs_bound $pvcs_failed $pvcs_terminating
+        printf " 🔹 PVs: % 4d (% 4d bound, % 4d released)\n" $pvs_count $pvs_bound $pvs_released
+    else
+        skipped=1
+        printf "."
+    fi
+}
+
+while sleep 1; do
+    update
+    printupdate
+done

--- a/example/pvc-hell.sh
+++ b/example/pvc-hell.sh
@@ -9,7 +9,9 @@ fi
 ACTION=$1
 QUANTITY=$2
 
-echo ${ACTION} ${QUANTITY} pods and PVC
+echo ""
+echo "pvc-hell ${ACTION} ${QUANTITY} pods and PVC"
+echo ""
 
 rm -f /tmp/pvc-hell.yaml
 for ((i=1; i <= QUANTITY; i++)); do

--- a/pkg/common/system.go
+++ b/pkg/common/system.go
@@ -119,10 +119,21 @@ func VolumeIdGetStorageProtocol(volumeId string) (string, error) {
 	}
 }
 
-// VolumeIdAugment: Extend the volume name by augmenting it with storage protocol
-func VolumeIdAugment(volumename, storageprotocol string) string {
+// VolumeIdGetWwn: Decode the augmented volume identifier and return the WWN
+func VolumeIdGetWwn(volumeId string) (string, error) {
+	tokens := strings.Split(volumeId, AugmentKey)
 
-	volumeId := volumename + AugmentKey + storageprotocol
+	if len(tokens) > 2 {
+		return tokens[2], nil
+	} else {
+		return "", fmt.Errorf("Unable to retrieve wwn from (%s)", volumeId)
+	}
+}
+
+// VolumeIdAugment: Extend the volume name by augmenting it with storage protocol
+func VolumeIdAugment(volumename, storageprotocol, wwn string) string {
+
+	volumeId := volumename + AugmentKey + storageprotocol + AugmentKey + wwn
 	klog.V(2).Infof("VolumeIdAugment: %s", volumeId)
 	return volumeId
 }

--- a/pkg/controller/provisioner.go
+++ b/pkg/controller/provisioner.go
@@ -48,6 +48,7 @@ func (controller *Controller) CreateVolume(ctx context.Context, req *csi.CreateV
 	sizeStr := getSizeStr(size)
 	pool := parameters[common.PoolConfigKey]
 	poolType, _ := controller.client.Info.GetPoolType(pool)
+	wwn := ""
 
 	if len(poolType) == 0 {
 		poolType = "Virtual"
@@ -111,7 +112,8 @@ func (controller *Controller) CreateVolume(ctx context.Context, req *csi.CreateV
 		klog.V(2).Infof("Storing iSCSI iqn: %s, portals: %v", targetId, portals)
 	}
 
-	volumeId := common.VolumeIdAugment(volumeName, storageProtocol)
+	wwn, _ = controller.client.GetVolumeWwn(volumeName)
+	volumeId := common.VolumeIdAugment(volumeName, storageProtocol, wwn)
 
 	volume := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{

--- a/pkg/controller/publisher.go
+++ b/pkg/controller/publisher.go
@@ -37,7 +37,7 @@ func (driver *Controller) ControllerPublishVolume(ctx context.Context, req *csi.
 	}, err
 }
 
-// ControllerUnpublishVolume deattaches the given volume from the node
+// ControllerUnpublishVolume detaches the given volume from the node
 func (driver *Controller) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "cannot unpublish volume with empty ID")

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -117,7 +117,7 @@ func (node *Node) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapab
 	}
 
 	for _, cap := range cl {
-		klog.V(4).Infof("enabled node service capability: %v", cap.String())
+		// klog.V(4).Infof("enabled node service capability: %v", cap.String())
 		csc = append(csc, &csi.NodeServiceCapability{
 			Type: &csi.NodeServiceCapability_Rpc{
 				Rpc: &csi.NodeServiceCapability_RPC{
@@ -224,7 +224,7 @@ func (node *Node) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVol
 
 // Probe returns the health and readiness of the plugin
 func (node *Node) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-	klog.V(4).Infof("Probe called with args: %#v", req)
+	// klog.V(4).Infof("Probe called with args: %#v", req)
 	return &csi.ProbeResponse{Ready: &wrappers.BoolValue{Value: true}}, nil
 }
 


### PR DESCRIPTION
- Added mutex to enforce single threading for all routine calls for debugging, but disabled until needed
- Added WWN to volume name to pass to the Node drivers
- Added mutex per volume to ensure NodePublishVolume and NodeUnpublishVolume are only called once sequentially
- Detect is /dev/disk/by-path/ip-lun device exists before the iscsi login (debug only)
- Wait for /dev/disk/by-id/dm-name-3<wwn> to show up before proceeding, also used for debugging
- Additional debug calls for troubleshooting device issues