### PR TITLE
Feat/sas

### DIFF
--- a/docs/sas/app.yaml
+++ b/docs/sas/app.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-seagate
+  namespace: demo
+spec:
+  containers:
+  - image: gcr.io/google-containers/busybox:latest
+    name: theapp
+    volumeMounts:
+    - mountPath: /vol
+      name: volume-seagate
+    command: [ "sleep", "1000" ]
+  volumes:
+  - name: volume-seagate
+    persistentVolumeClaim:
+      claimName: pvc-seagate

--- a/docs/sas/clonepvc.yaml
+++ b/docs/sas/clonepvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-clone-seagate
+  namespace: demo
+spec:
+  dataSource:
+    name: pvc-seagate
+    kind: PersistentVolumeClaim
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: storageclass-seagate
+  resources:
+    requests:
+      storage: 1Gi

--- a/docs/sas/multipath.conf
+++ b/docs/sas/multipath.conf
@@ -1,0 +1,111 @@
+defaults {
+	polling_interval 		2
+	#path_selector			"round-robin 0"
+	#path_grouping_policy		failover
+	#prio				alua
+	#path_checker			tur
+	#rr_min_io			3
+	#flush_on_last_del		no
+	#max_fds				max
+	#rr_weight			priorities
+	#failback			immediate
+	#no_path_retry			18
+	#queue_without_daemon   	 	no
+	user_friendly_names		"no"
+        find_multipaths "yes"
+        retain_attached_hw_handler "no"
+        disable_changed_wwids "yes"
+}
+
+blacklist {
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^hd[a-z][[0-9]*]"
+	wwid _USB_DISK_2.0_070C352825C2DA48-0:0
+	#wwid iDRAC_OEMDRV_20120731-0:0
+}
+devices {
+        device {
+                vendor "VERITAS"
+                product "STX_5005"
+                uid_attribute   ID_SERIAL
+                path_grouping_policy "group_by_prio"
+                path_checker "tur"
+                features "0"
+                hardware_handler "0"
+                prio "alua"
+                failback immediate
+                rr_weight "uniform"
+                no_path_retry 18
+                rr_min_io 3
+        }
+        device {
+                vendor "DellEMC"
+                product "ME*"
+                uid_attribute   ID_SERIAL
+                path_grouping_policy "group_by_prio"
+                path_checker "tur"
+                features "0"
+                hardware_handler "0"
+                prio "alua"
+                failback immediate
+                rr_weight "uniform"
+                no_path_retry 18
+                rr_min_io 3
+        }
+       device {
+                vendor "SEAGATE"
+                product "3*"
+		uid_attribute	ID_SERIAL
+                path_grouping_policy "group_by_prio"
+                path_checker "tur"
+                features "0"
+                hardware_handler "0"
+                prio "alua"
+                failback immediate
+                rr_weight "uniform"
+                no_path_retry 18
+                rr_min_io 3
+        }
+       device {
+                vendor "HPE"
+                product "MSA 2060*"
+		uid_attribute	ID_SERIAL
+                path_grouping_policy "group_by_prio"
+                path_checker "tur"
+                features "0"
+                hardware_handler "0"
+                prio "alua"
+                failback immediate
+                rr_weight "uniform"
+                no_path_retry 18
+                rr_min_io 3
+        }
+       device {
+                vendor "HPE"
+                product "MSA 1060*"
+		uid_attribute	ID_SERIAL
+                path_grouping_policy "group_by_prio"
+                path_checker "tur"
+                features "0"
+                hardware_handler "0"
+                prio "alua"
+                failback immediate
+                rr_weight "uniform"
+                no_path_retry 18
+                rr_min_io 3
+        }
+       device {
+                vendor "Lenovo"
+		product "DS6200"
+		uid_attribute	ID_SERIAL
+                path_grouping_policy "group_by_prio"
+                path_checker "tur"
+                features "0"
+                hardware_handler "0"
+                prio "alua"
+                failback immediate
+                rr_weight "uniform"
+                no_path_retry 18
+                rr_min_io 100
+        }
+}

--- a/docs/sas/multipath.conf
+++ b/docs/sas/multipath.conf
@@ -40,7 +40,7 @@ devices {
         }
         device {
                 vendor "DellEMC"
-                product "ME*"
+                product "ME[45].*"
                 uid_attribute   ID_SERIAL
                 path_grouping_policy "group_by_prio"
                 path_checker "tur"
@@ -54,7 +54,7 @@ devices {
         }
        device {
                 vendor "SEAGATE"
-                product "3*"
+                product "[456][0-9][0-9][456]"
 		uid_attribute	ID_SERIAL
                 path_grouping_policy "group_by_prio"
                 path_checker "tur"
@@ -68,21 +68,7 @@ devices {
         }
        device {
                 vendor "HPE"
-                product "MSA 2060*"
-		uid_attribute	ID_SERIAL
-                path_grouping_policy "group_by_prio"
-                path_checker "tur"
-                features "0"
-                hardware_handler "0"
-                prio "alua"
-                failback immediate
-                rr_weight "uniform"
-                no_path_retry 18
-                rr_min_io 3
-        }
-       device {
-                vendor "HPE"
-                product "MSA 1060*"
+                product "MSA [12]0[456]0.*"
 		uid_attribute	ID_SERIAL
                 path_grouping_policy "group_by_prio"
                 path_checker "tur"
@@ -96,7 +82,7 @@ devices {
         }
        device {
                 vendor "Lenovo"
-		product "DS6200"
+		product "[D]?S[2346]200"
 		uid_attribute	ID_SERIAL
                 path_grouping_policy "group_by_prio"
                 path_checker "tur"

--- a/docs/sas/pvc.yaml
+++ b/docs/sas/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-seagate
+  namespace: demo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: storageclass-seagate
+  resources:
+    requests:
+      storage: 1Gi

--- a/docs/sas/restoresnapshot.yaml
+++ b/docs/sas/restoresnapshot.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-restore-seagate
+  namespace: demo
+spec:
+  dataSource:
+    name: snapshot-seagate
+    kind: VolumeSnapshot
+    apiGroup: "snapshot.storage.k8s.io"
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: storageclass-seagate
+  resources:
+    requests:
+      storage: 1Gi

--- a/docs/sas/secret-seagate.yaml
+++ b/docs/sas/secret-seagate.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: seagate-enclosure001
+  namespace: seagate
+type: Opaque
+data:
+  apiAddress: TBD # base64 encoded api address http://192.168.0.1
+  username: TBD # base64 encoded username
+  password: TBD # base64 encoded password

--- a/docs/sas/storage-class.yaml
+++ b/docs/sas/storage-class.yaml
@@ -1,0 +1,18 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+provisioner: csi-exos-x.seagate.com
+allowVolumeExpansion: true
+metadata:
+  name: storageclass-seagate
+parameters:
+  csi.storage.k8s.io/provisioner-secret-name: secret-seagate
+  csi.storage.k8s.io/provisioner-secret-namespace: seagate
+  csi.storage.k8s.io/controller-publish-secret-name: secret-seagate
+  csi.storage.k8s.io/controller-publish-secret-namespace: seagate
+  csi.storage.k8s.io/controller-expand-secret-name: secret-seagate
+  csi.storage.k8s.io/controller-expand-secret-namespace: seagate
+  fsType: ext4 # Desired filesystem
+  pool: A # Pool for volumes provisioning
+  volPrefix: stx # Desired prefix for volume naming, an underscore is appended
+  storageProtocol: sas # The storage interface (iscsi, fc, sas) being used for storage i/o
+  wwns: 500605b0091fbb20, 500605b0091fbb21

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/Seagate/csi-lib-iscsi v1.0.3
+	github.com/Seagate/csi-lib-sas v0.0.0-00010101000000-000000000000
 	github.com/Seagate/seagate-exos-x-api-go v1.0.8-0.20220531203625-3d1a38b18ac6
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/container-storage-interface/spec v1.4.0
@@ -25,3 +26,4 @@ require (
 
 // replace github.com/Seagate/seagate-exos-x-api-go => ../seagate-exos-x-api-go
 // replace github.com/Seagate/csi-lib-iscsi => ../csi-lib-iscsi
+replace github.com/Seagate/csi-lib-sas => ../csi-lib-sas

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -134,6 +136,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -752,6 +755,8 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/klog/v2 v2.70.0 h1:GMmmjoFOrNepPN0ZeGCzvD2Gh5IKRwdFx8W5PBxVTQU=
+k8s.io/klog/v2 v2.70.0/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/common/driver.go
+++ b/pkg/common/driver.go
@@ -33,6 +33,7 @@ const (
 	PasswordSecretKey         = "password"
 	StorageClassAnnotationKey = "storageClass"
 	VolumePrefixKey           = "volPrefix"
+	WWNs                      = "wwns"
 	StorageProtocolKey        = "storageProtocol"
 	StorageProtocolISCSI      = "iscsi"
 	StorageProtocolFC         = "fc"

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -140,10 +140,8 @@ func (node *Node) NodePublishVolume(ctx context.Context, req *csi.NodePublishVol
 	klog.Infof("NodePublishVolume called with volume name %s", volumeName)
 
 	config := make(map[string]string)
-	if storageProtocol == common.StorageProtocolISCSI {
-		config["iscsiInfoPath"] = node.getIscsiInfoPath(volumeName)
-		klog.V(2).Infof("NodePublishVolume iscsiInfoPath (%v)", config["iscsiInfoPath"])
-	}
+	config["connectorInfoPath"] = node.getConnectorInfoPath(storageProtocol, volumeName)
+	klog.V(2).Infof("NodePublishVolume connectorInfoPath (%v)", config["connectorInfoPath"])
 
 	// Get storage handler
 	storageNode, err := storage.NewStorageNode(storageProtocol, config)
@@ -165,8 +163,8 @@ func (node *Node) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublis
 	klog.Infof("NodeUnpublishVolume volume %s at target path %s", volumeName, req.GetTargetPath())
 
 	config := make(map[string]string)
-	config["iscsiInfoPath"] = node.getIscsiInfoPath(volumeName)
-	klog.V(2).Infof("NodeUnpublishVolume iscsiInfoPath (%v)", config["iscsiInfoPath"])
+	config["connectorInfoPath"] = node.getConnectorInfoPath(storageProtocol, volumeName)
+	klog.V(2).Infof("NodeUnpublishVolume connectorInfoPath (%v)", config["connectorInfoPath"])
 
 	// Get storage handler
 	storageNode, err := storage.NewStorageNode(storageProtocol, config)
@@ -188,8 +186,8 @@ func (node *Node) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 	klog.Infof("NodeExpandVolume volume %s at volume path %s", volumeName, req.GetVolumePath())
 
 	config := make(map[string]string)
-	config["iscsiInfoPath"] = node.getIscsiInfoPath(volumeName)
-	klog.V(2).Infof("NodeExpandVolume iscsiInfoPath (%v)", config["iscsiInfoPath"])
+	config["connectorInfoPath"] = node.getConnectorInfoPath(storageProtocol, volumeName)
+	klog.V(2).Infof("NodeExpandVolume connectorInfoPath (%v)", config["connectorInfoPath"])
 
 	// Get storage handler
 	storageNode, err := storage.NewStorageNode(storageProtocol, config)
@@ -228,9 +226,9 @@ func (node *Node) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeR
 	return &csi.ProbeResponse{Ready: &wrappers.BoolValue{Value: true}}, nil
 }
 
-// getIscsiInfoPath
-func (node *Node) getIscsiInfoPath(volumeID string) string {
-	return fmt.Sprintf("%s/iscsi-%s.json", node.runPath, volumeID)
+// getConnectorInfoPath
+func (node *Node) getConnectorInfoPath(storageProtocol, volumeID string) string {
+	return fmt.Sprintf("%s/%s-%s.json", node.runPath, storageProtocol, volumeID)
 }
 
 // checkHostBinary: Determine if a binary image is installed or not
@@ -244,7 +242,7 @@ func checkHostBinary(name string) error {
 	return nil
 }
 
-// readInitiatorName: Extract the initiaotr name from /etc/iscsi file
+// readInitiatorName: Extract the initiator name from /etc/iscsi file
 func readInitiatorName() (string, error) {
 	initiatorNameFilePath := "/etc/iscsi/initiatorname.iscsi"
 	file, err := os.Open(initiatorNameFilePath)

--- a/pkg/storage/iscsiNode.go
+++ b/pkg/storage/iscsiNode.go
@@ -206,11 +206,11 @@ func (iscsi *iscsiStorage) NodePublishVolume(ctx context.Context, req *csi.NodeP
 		return nil, errors.New("device has already been mounted in several locations, please unmount first")
 	}
 
-	klog.Infof("saving ISCSI connection info in %s", iscsi.iscsiInfoPath)
-	if _, err := os.Stat(iscsi.iscsiInfoPath); err == nil {
-		klog.Warningf("iscsi connection file already exists: %s", iscsi.iscsiInfoPath)
+	klog.Infof("saving ISCSI connection info in %s", iscsi.connectorInfoPath)
+	if _, err := os.Stat(iscsi.connectorInfoPath); err == nil {
+		klog.Warningf("iscsi connection file already exists: %s", iscsi.connectorInfoPath)
 	}
-	err = iscsilib.PersistConnector(&connector, iscsi.iscsiInfoPath)
+	err = iscsilib.PersistConnector(&connector, iscsi.connectorInfoPath)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -259,8 +259,8 @@ func (iscsi *iscsiStorage) NodeUnpublishVolume(ctx context.Context, req *csi.Nod
 		klog.Warningf("assuming that volume is already unmounted: %v", err)
 	}
 
-	klog.Infof("loading ISCSI connection info from %s", iscsi.iscsiInfoPath)
-	connector, err := iscsilib.GetConnectorFromFile(iscsi.iscsiInfoPath)
+	klog.Infof("loading ISCSI connection info from %s", iscsi.connectorInfoPath)
+	connector, err := iscsilib.GetConnectorFromFile(iscsi.connectorInfoPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			klog.Warning(errors.Wrap(err, "assuming that ISCSI connection is already closed"))
@@ -301,8 +301,8 @@ func (iscsi *iscsiStorage) NodeUnpublishVolume(ctx context.Context, req *csi.Nod
 		return nil, err
 	}
 
-	klog.Infof("deleting ISCSI connection info file %s", iscsi.iscsiInfoPath)
-	os.Remove(iscsi.iscsiInfoPath)
+	klog.Infof("deleting ISCSI connection info file %s", iscsi.connectorInfoPath)
+	os.Remove(iscsi.connectorInfoPath)
 
 	klog.Info("successfully detached ISCSI device")
 	return &csi.NodeUnpublishVolumeResponse{}, nil
@@ -329,7 +329,7 @@ func (iscsi *iscsiStorage) NodeExpandVolume(ctx context.Context, req *csi.NodeEx
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("node expand volume requires volume path"))
 	}
 
-	connector, err := iscsilib.GetConnectorFromFile(iscsi.iscsiInfoPath)
+	connector, err := iscsilib.GetConnectorFromFile(iscsi.connectorInfoPath)
 	klog.V(3).Infof("GetConnectorFromFile(%s) connector: %v, err: %v", volumeName, connector, err)
 
 	if err != nil {

--- a/pkg/storage/storageService.go
+++ b/pkg/storage/storageService.go
@@ -36,16 +36,18 @@ type commonService struct {
 }
 
 type fcStorage struct {
-	cs commonService
+	cs                commonService
+	connectorInfoPath string
 }
 
 type iscsiStorage struct {
-	cs            commonService
-	iscsiInfoPath string
+	cs                commonService
+	connectorInfoPath string
 }
 
 type sasStorage struct {
-	cs commonService
+	cs                commonService
+	connectorInfoPath string
 }
 
 // buildCommonService:
@@ -63,15 +65,15 @@ func NewStorageNode(storageProtocol string, config map[string]string) (StorageOp
 		storageProtocol = strings.TrimSpace(storageProtocol)
 		klog.V(2).Infof("NewStorageNode for (%s)", storageProtocol)
 		if storageProtocol == common.StorageProtocolFC {
-			return &fcStorage{cs: comnserv}, nil
+			return &fcStorage{cs: comnserv, connectorInfoPath: config["connectorInfoPath"]}, nil
 		} else if storageProtocol == common.StorageProtocolSAS {
-			return &sasStorage{cs: comnserv}, nil
+			return &sasStorage{cs: comnserv, connectorInfoPath: config["connectorInfoPath"]}, nil
 		} else if storageProtocol == common.StorageProtocolISCSI {
-			return &iscsiStorage{cs: comnserv, iscsiInfoPath: config["iscsiInfoPath"]}, nil
+			return &iscsiStorage{cs: comnserv, connectorInfoPath: config["connectorInfoPath"]}, nil
 		} else {
 			klog.Warningf("Invalid or no storage protocol specified (%s)", storageProtocol)
 			klog.Warningf("Expecting storageProtocol (iscsi, fc, sas, etc) in StorageClass YAML. Default of (%s) used.", common.StorageProtocolISCSI)
-			return &iscsiStorage{cs: comnserv, iscsiInfoPath: config["iscsiInfoPath"]}, nil
+			return &iscsiStorage{cs: comnserv, connectorInfoPath: config["connectorInfoPath"]}, nil
 		}
 	}
 	return nil, err


### PR DESCRIPTION
The main purpose of this request is to complete the SAS interface of the storage service and provide SAS support.

Release Notes:
- New docs/sas example yaml files, with new storage class parameter 'wwns'
- Current SAS implementation requires 'wwns' parameter in StorageClass, will look to automate
- iscsi specific connector information changed to generic labeling of 'connectorInfoPath'
- Several common functions moved from iSCSI to storageService
- Completion of sasNode interface routines: NodePublishVolume, NodeUnpublishVolume, and NodeExpandVolume
