### PR TITLE
test: add option to specify imagePullSecrets

### DIFF
--- a/helm/csi-charts/templates/daemonset.yaml
+++ b/helm/csi-charts/templates/daemonset.yaml
@@ -86,6 +86,10 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       volumes:
         - name: registration-dir
           hostPath:

--- a/helm/csi-charts/templates/deployment.yaml
+++ b/helm/csi-charts/templates/deployment.yaml
@@ -76,6 +76,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       volumes:
         - name: socket-dir
           emptyDir:


### PR DESCRIPTION
imagePullSecrets may be needed if pulling the driver container images
from a registry that requires authentication. This can be useful for
development or if the external registries are not directly accessible