### PR TITLE
Feat/saswwn

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Seagate/csi-lib-iscsi v1.0.3
-	github.com/Seagate/csi-lib-sas v1.0.0
+	github.com/Seagate/csi-lib-sas v1.0.1
 	github.com/Seagate/seagate-exos-x-api-go v1.0.8-0.20220531203625-3d1a38b18ac6
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/container-storage-interface/spec v1.4.0
@@ -26,4 +26,4 @@ require (
 
 // replace github.com/Seagate/seagate-exos-x-api-go => ../seagate-exos-x-api-go
 // replace github.com/Seagate/csi-lib-iscsi => ../csi-lib-iscsi
-replace github.com/Seagate/csi-lib-sas => ../csi-lib-sas
+// replace github.com/Seagate/csi-lib-sas => ../csi-lib-sas

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Seagate/csi-lib-iscsi v1.0.3
-	github.com/Seagate/csi-lib-sas v0.0.0-00010101000000-000000000000
+	github.com/Seagate/csi-lib-sas v1.0.0
 	github.com/Seagate/seagate-exos-x-api-go v1.0.8-0.20220531203625-3d1a38b18ac6
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/container-storage-interface/spec v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Seagate/csi-lib-iscsi v1.0.3 h1:PEPCySqKmdRwgyM4vb/cugFVyNbo5JL+f/J7W4Q/WVw=
 github.com/Seagate/csi-lib-iscsi v1.0.3/go.mod h1:sp7ftl8BMVgMNybv3sw8V20MJsX0bl2w5BoSFlBRPkY=
+github.com/Seagate/csi-lib-sas v1.0.1 h1:7qIFiQ7YORsvKlGxCL4XguadMBmIBeis45BoB29PMg0=
+github.com/Seagate/csi-lib-sas v1.0.1/go.mod h1:lX/OnO0sLm4vXCFwsPADyzZxSFkmXv5t+WleiYNkN8U=
 github.com/Seagate/seagate-exos-x-api-go v1.0.8-0.20220531203625-3d1a38b18ac6 h1:jf6/xR3cKfVW8v1xxC8E3eTqLlrolQx/hUi8fRTgfWI=
 github.com/Seagate/seagate-exos-x-api-go v1.0.8-0.20220531203625-3d1a38b18ac6/go.mod h1:BAbcvtjsD9uKUdJbypktpa/gQ75TH3wWqC8L4Exd3ac=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=


### PR DESCRIPTION
The main purpose of this request is to update the CSI Driver's usage of csi-lib-sas to the new API changes.

Release Notes:
- Upgrade to github.com/Seagate/csi-lib-sas v1.0.0
- Change to use only Volume WWN for SAS Connector
- Changes to saslib.Attach to pass pointer to Connector, since values are updated
- The field connector.DevicePath was renamed connector.TargetDevice
- Connector.TargetDevice is a SCSI drive or a multipath device based on connector.Multipath true|false
