### PR TITLE
fix: Add volume mount for controller run dir

### DIFF
--- a/helm/csi-charts/templates/deployment.yaml
+++ b/helm/csi-charts/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+            - name: csi-run-dir
+              mountPath: /var/run/csi-exos-x.seagate.com
           ports:
             - containerPort: 9842
               name: metrics
@@ -84,3 +86,6 @@ spec:
         - name: socket-dir
           emptyDir:
             medium: Memory
+        - name: csi-run-dir
+          hostPath:
+            path: /var/run/csi-exos-x.seagate.com


### PR DESCRIPTION
Error when starting up the controller deployment as this directory doesn't exist in the helm charts yet. 

Add the volume mount for the "run dir" to the deployment for the controller, used for storage of initiator map information