### PR TITLE
fix: Pass node ID with the topology map for initiator selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	google.golang.org/grpc v1.50.0
-	k8s.io/klog/v2 v2.70.0
+	k8s.io/klog/v2 v2.80.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -741,8 +741,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog/v2 v2.70.0 h1:GMmmjoFOrNepPN0ZeGCzvD2Gh5IKRwdFx8W5PBxVTQU=
-k8s.io/klog/v2 v2.70.0/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
+k8s.io/klog/v2 v2.80.1 h1:atnLQ121W371wYYFawwYx1aEY2eUfs4l3J72wtgAwV4=
+k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/helm/csi-charts/values.yaml
+++ b/helm/csi-charts/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/seagate/seagate-exos-x-csi
   # -- Tag to use for nodes and controller
   # @default -- Uses Chart.appVersion value by default if tag does not specify a new version.
-  tag: "v1.5.3" 
+  tag: "v1.5.4" 
   # -- Default is set to IfNotPresent, to override use Always here to always pull the specified version
   pullPolicy: Always
 

--- a/pkg/common/driver.go
+++ b/pkg/common/driver.go
@@ -40,6 +40,8 @@ const (
 	StorageProtocolSAS        = "sas"
 	TopologyInitiatorPrefix   = "com.seagate-exos-x-csi"
 	TopologySASInitiatorLabel = "sas-address"
+	TopologyNodeIdentifier    = "node-id"
+	TopologyNodeIDKey         = TopologyInitiatorPrefix + "/" + TopologyNodeIdentifier
 
 	MaximumLUN            = 255
 	VolumeNameMaxLength   = 32

--- a/pkg/common/system.go
+++ b/pkg/common/system.go
@@ -137,3 +137,8 @@ func VolumeIdAugment(volumename, storageprotocol, wwn string) string {
 	klog.V(2).Infof("VolumeIdAugment: %s", volumeId)
 	return volumeId
 }
+
+// We use IQN for Node ID, but IQN can contain colons which are not allowed in the topology map
+func GetTopologyCompliantNodeID(nodeID string) string {
+	return strings.ReplaceAll(nodeID, ":", ".")
+}

--- a/pkg/controller/publisher.go
+++ b/pkg/controller/publisher.go
@@ -73,13 +73,12 @@ func (driver *Controller) ControllerPublishVolume(ctx context.Context, req *csi.
 	}
 	parameters := req.GetVolumeContext()
 
-	volumeName, _ := common.VolumeIdGetName(req.GetVolumeId())
-
+	initiatorMapNodeID := common.GetTopologyCompliantNodeID(req.GetNodeId())
 	var initiatorNames []string
 	// Available SAS initiators for the node are provided here through NodeGetInfo
 	if parameters[common.StorageProtocolKey] == common.StorageProtocolSAS {
 		for key, val := range parameters {
-			if strings.Contains(key, common.TopologyInitiatorPrefix) {
+			if strings.Contains(key, common.TopologySASInitiatorLabel) && strings.Contains(key, initiatorMapNodeID) {
 				initiatorNames = append(initiatorNames, val)
 			}
 		}
@@ -87,6 +86,7 @@ func (driver *Controller) ControllerPublishVolume(ctx context.Context, req *csi.
 		initiatorNames = []string{req.GetNodeId()}
 	}
 
+	volumeName, _ := common.VolumeIdGetName(req.GetVolumeId())
 	persistentInfoFilepath := driver.getConnectorInfoPath(req.GetVolumeId())
 	persistInitiatorMap(volumeName, initiatorNames, persistentInfoFilepath)
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -118,6 +118,8 @@ func (node *Node) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 		topology[topoKey] = sasAddr
 	}
 
+	topology[common.TopologyNodeIDKey] = common.GetTopologyCompliantNodeID(initiatorName)
+
 	return &csi.NodeGetInfoResponse{
 		NodeId:            initiatorName,
 		MaxVolumesPerNode: 255,


### PR DESCRIPTION
Pass the node ID with the topology map so ControllerPublishVolume can tell which initiators are present on the scheduled node