### PR TITLE
fix: Fix XFS compatibility and return accessible topology

### DIFF
--- a/docs/sas/README.md
+++ b/docs/sas/README.md
@@ -1,3 +1,5 @@
+The CSI driver SAS support requires that all nodes have access to the SAS array. 
+
 # Specifying SAS Initiators
 
 ## SAS Initiator Discovery
@@ -17,17 +19,4 @@ Example contents of the `sas-addresses` file, **note that the '0x' prefix is omi
 ```
 500605b00b4ec831
 500605b00b4ec832
-```
-
-## Specify your initiator as a topology value in your storage class:
-Use the CSI Topology feature to ensure your PVCs are only scheduled on Nodes that are connected to your SAS array. If this field is not present in your storage class, PVCs for this storage class
-may be scheduled on Nodes that are not connected to the array and they will fail.
-
-Also see the storage class example file in this directory
-```
-allowedTopologies:
-  - matchLabelExpressions:
-    - key: com.seagate-exos-x-csi/sas-address-0
-      values:
-      - 500605b00b4ec831 # The first sas initiator on your node
 ```

--- a/helm/csi-charts/values.yaml
+++ b/helm/csi-charts/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/seagate/seagate-exos-x-csi
   # -- Tag to use for nodes and controller
   # @default -- Uses Chart.appVersion value by default if tag does not specify a new version.
-  tag: "v1.5.4" 
+  tag: "v1.5.6" 
   # -- Default is set to IfNotPresent, to override use Always here to always pull the specified version
   pullPolicy: Always
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -120,6 +120,7 @@ func (node *Node) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 
 	topology[common.TopologyNodeIDKey] = common.GetTopologyCompliantNodeID(initiatorName)
 
+	klog.Infof("Node Accessible Topology: %v", topology)
 	return &csi.NodeGetInfoResponse{
 		NodeId:            initiatorName,
 		MaxVolumesPerNode: 255,

--- a/pkg/storage/fcNode.go
+++ b/pkg/storage/fcNode.go
@@ -87,7 +87,7 @@ func (fc *fcStorage) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	}
 
 	corrupted := false
-	if err = CheckFs(path, "Publish"); err != nil {
+	if err = CheckFs(path, fsType, "Publish"); err != nil {
 		corrupted = true
 	}
 
@@ -203,18 +203,8 @@ func (fc *fcStorage) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpub
 	}
 
 	wwn, _ := common.VolumeIdGetWwn(req.GetVolumeId())
-	exists := true
 	out, err := exec.Command("ls", "-l", fmt.Sprintf("/dev/disk/by-id/dm-name-3%s", wwn)).CombinedOutput()
 	klog.Infof("check for dm-name: ls -l %s, err = %v, out = \n%s", fmt.Sprintf("/dev/disk/by-id/dm-name-3%s", wwn), err, string(out))
-	if err != nil {
-		exists = false
-	}
-
-	if err = CheckFs(connector.OSPathName, "Unpublish"); err != nil {
-		klog.Infof("device corruption (unpublish), device=%v, volume=%s, multipath=%v, wwn=%v, exists=%v, corrupted=%v", connector.OSPathName, volumeName, connector.Multipath, wwn, exists, true)
-		DebugCorruption("!!", connector.OSPathName)
-		return nil, status.Errorf(codes.DataLoss, "(unpublish) filesystem seems to be corrupted: %v", err)
-	}
 
 	klog.Info("DisconnectVolume, detaching device")
 	err = fclib.Detach(ctx, connector.OSPathName, connector.IoHandler)

--- a/pkg/storage/storageService.go
+++ b/pkg/storage/storageService.go
@@ -111,10 +111,14 @@ func RemoveGatekeeper(volumeName string) {
 	gatekeepers.Unlock(volumeName)
 }
 
-// CheckFs: Perform a file system validation using fsck
-func CheckFs(path string, context string) error {
-	klog.Infof("Checking filesystem (e2fsck -n %s) [%s]", path, context)
-	if out, err := exec.Command("e2fsck", "-n", path).CombinedOutput(); err != nil {
+// CheckFs: Perform a file system validation
+func CheckFs(path string, fstype string, context string) error {
+	fsRepairCommand := "e2fsck"
+	if fstype == "xfs" {
+		fsRepairCommand = "xfs_repair"
+	}
+	klog.Infof("Checking filesystem (%s -n %s) [%s]", fsRepairCommand, path, context)
+	if out, err := exec.Command(fsRepairCommand, "-n", path).CombinedOutput(); err != nil {
 		return errors.New(string(out))
 	}
 	return nil


### PR DESCRIPTION
Fixes a bug with XFS when checking for filesystem corruption. Removes corruption checks at Unpublish. Also adds topology parsing code to return accessibleTopology from Create Volume, which may be used by a CO scheduler in the future to determine pod scheduling requirements based on storage accessibility