### PR TITLE
fix(snapshots): Use 31 char volume names for copy volume

### DIFF
--- a/pkg/common/driver.go
+++ b/pkg/common/driver.go
@@ -44,7 +44,7 @@ const (
 	TopologyNodeIDKey         = TopologyInitiatorPrefix + "/" + TopologyNodeIdentifier
 
 	MaximumLUN            = 255
-	VolumeNameMaxLength   = 32
+	VolumeNameMaxLength   = 31
 	VolumePrefixMaxLength = 3
 )
 


### PR DESCRIPTION
Use a 31 character destination volume name to work around a controller issue that causes 32 character names to get truncated

resolves #61 