### PR TITLE
fix: Do not run filesystem checks if fs is already mounted

### DIFF
--- a/pkg/storage/storageService.go
+++ b/pkg/storage/storageService.go
@@ -113,6 +113,12 @@ func RemoveGatekeeper(volumeName string) {
 
 // CheckFs: Perform a file system validation
 func CheckFs(path string, fstype string, context string) error {
+
+	if IsVolumeInUse(path) {
+		klog.Infof("Volume already mounted, not performing FS check")
+		return nil
+	}
+
 	fsRepairCommand := "e2fsck"
 	if fstype == "xfs" {
 		fsRepairCommand = "xfs_repair"


### PR DESCRIPTION
In order to meet idempotency requirements, don't run (and fail) FS checks on an already mounted filesystem in NodePublishVolume