### PR TITLE
fix: Add support for prefixed fstype parameter

### DIFF
--- a/example/storage-class.yaml
+++ b/example/storage-class.yaml
@@ -13,6 +13,6 @@ parameters:
   csi.storage.k8s.io/controller-publish-secret-namespace: default
   csi.storage.k8s.io/controller-expand-secret-name: seagate-exos-x-csi-secrets
   csi.storage.k8s.io/controller-expand-secret-namespace: default
-  fsType: ext4 # Desired filesystem
+  csi.storage.k8s.io/fstype: ext4 # Desired filesystem
   pool: A # Pool to use on the IQN to provision volumes
   storageProtocol: iscsi # The storage interface (iscsi, fc, sas) being used for storage i/o

--- a/example/storageclass-example1.yaml
+++ b/example/storageclass-example1.yaml
@@ -13,7 +13,7 @@ parameters:
   csi.storage.k8s.io/controller-publish-secret-namespace: default
   csi.storage.k8s.io/controller-expand-secret-name: seagate-exos-x-csi-secrets
   csi.storage.k8s.io/controller-expand-secret-namespace: default
-  fsType: ext4 # Desired filesystem
+  csi.storage.k8s.io/fstype: ext4 # Desired filesystem
   pool: A # Pool to use on the IQN to provision volumes
   volPrefix: csi # Desired prefix for volume naming, an underscore is appended
   storageProtocol: iscsi # The storage interface (iscsi, fc, sas) being used for storage i/o

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -275,9 +275,6 @@ func runPreflightChecks(parameters map[string]string, capabilities *[]*csi.Volum
 		return nil
 	}
 
-	if err := checkIfKeyExistsInConfig(common.FsTypeConfigKey); err != nil {
-		return err
-	}
 	if err := checkIfKeyExistsInConfig(common.PoolConfigKey); err != nil {
 		return err
 	}
@@ -289,6 +286,14 @@ func runPreflightChecks(parameters map[string]string, capabilities *[]*csi.Volum
 		for _, capability := range *capabilities {
 			if capability.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
 				return status.Error(codes.FailedPrecondition, "storage only supports ReadWriteOnce access mode")
+			}
+			if capability.GetMount().GetFsType() == "" {
+				if err := checkIfKeyExistsInConfig(common.FsTypeConfigKey); err != nil {
+					return status.Error(codes.FailedPrecondition, "no fstype specified in storage class")
+				} else {
+					klog.Warningf("storage class parameter %s is deprecated. Please migrate to 'csi.storage.k8s.io/fstype'",
+						common.FsTypeConfigKey)
+				}
 			}
 		}
 	}

--- a/pkg/storage/fcNode.go
+++ b/pkg/storage/fcNode.go
@@ -87,7 +87,7 @@ func (fc *fcStorage) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	// check if previously unpublished devices were rediscovered by the scsi subsystem during Attach
 	checkPreviouslyRemovedDevices(ctx)
 
-	fsType := req.GetVolumeContext()[common.FsTypeConfigKey]
+	fsType := GetFsType(req)
 	err = EnsureFsType(fsType, path)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/storage/iscsiNode.go
+++ b/pkg/storage/iscsiNode.go
@@ -144,7 +144,7 @@ func (iscsi *iscsiStorage) NodePublishVolume(ctx context.Context, req *csi.NodeP
 		}
 	}
 
-	fsType := req.GetVolumeContext()[common.FsTypeConfigKey]
+	fsType := GetFsType(req)
 	err = EnsureFsType(fsType, path)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/storage/sasNode.go
+++ b/pkg/storage/sasNode.go
@@ -156,7 +156,7 @@ func (sas *sasStorage) NodePublishVolume(ctx context.Context, req *csi.NodePubli
 	// check if previously unpublished devices were rediscovered by the scsi subsystem during Attach
 	checkPreviouslyRemovedDevices(ctx)
 
-	fsType := req.GetVolumeContext()[common.FsTypeConfigKey]
+	fsType := GetFsType(req)
 	err = EnsureFsType(fsType, path)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/storage/storageService.go
+++ b/pkg/storage/storageService.go
@@ -119,6 +119,15 @@ func RemoveGatekeeper(volumeName string) {
 	gatekeepers.Unlock(volumeName)
 }
 
+// wrap the new FS type specification and fall back to the old parameter if necessary
+func GetFsType(req *csi.NodePublishVolumeRequest) string {
+	fsType := ""
+	if fsType = req.GetVolumeCapability().GetMount().GetFsType(); fsType == "" {
+		fsType = req.GetVolumeContext()[common.FsTypeConfigKey]
+	}
+	return fsType
+}
+
 // CheckFs: Perform a file system validation
 func CheckFs(path string, fstype string, context string) error {
 


### PR DESCRIPTION
The old FsType parameter used for storageClasses has been deprecated in favor of csi.storage.k8s.io/fstype, which is given special treatment by the csi external-provisioner. Add support for this parameter and warn if the deprecated version is being used