### PR TITLE
fix: Update workflow to use Openshift compliant Dockerfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ steps.imagelc.outputs.lowercase }}:${{ steps.fetch-latest-release.outputs.latest-release }}
           labels: ${{ steps.meta.outputs.labels }}
-          file: Dockerfile.ubi
+          file: Dockerfile.redhat
 
       - name: Inspect
         run: |


### PR DESCRIPTION
move our default release image from the UBI based container to the openshift compliant containers (Dockerfile.redhat)