### PR TITLE
build: Update github release action to use actions v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Release
       env:


### PR DESCRIPTION
The node version used in action checkout v2 is deprecated. Update to checkout v3