### PR TITLE
build: Add protocol buffer compiler to github runner for docker build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,11 @@ jobs:
       packages: write
 
     steps:
+      - name: Install protocol buffers compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          
       - name: Checkout
         uses: actions/checkout@v3
 


### PR DESCRIPTION
Install protocol buffer compiler 22.3 into the github runner during build to support the node gRPC service