### PR TITLE
certification automation, Helm chart formatting, README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,15 @@ This CSI driver is an open-source project under the Apache 2.0 [license](./LICEN
 
 `iscsid` and `multipathd` must be installed on every node. Check the
 installation method appropriate for your Linux distribution.  The
-example below shows steps for Ubuntu Server.
+example below shows steps for Ubuntu Server but the process will be
+very similar for other GNU/Linux distributions.
 
 #### Ubuntu Installation procedure
 - Remove any containers that were running an earlier version of the Seagate Exos X CSI Driver.
 - Install required packages:
 
     ```
-        sudo apt update && sudo apt install open-iscsi scsitools multipath-tools -y
+    sudo apt update && sudo apt install open-iscsi scsitools multipath-tools -y
     ```
 - Determine if any packages are required for your filesystem (ext3/ext4/xfs) choice and view current support:
 
@@ -66,22 +67,47 @@ example below shows steps for Ubuntu Server.
 - Restart `multipathd`:
 
     ```
-        service multipath-tools restart
+    service multipath-tools restart
     ```
 
 ### Deploy the provisioner to your kubernetes cluster
 
-The preferred installation approach is to use the provided `Helm Charts` under the helm folder.
+These examples assume you have already installed the [helm]() command.
+
+The easiest method for installing the driver is to use Helm to install
+the helm package from
+[Github](https://github.com/seagate/seagate-exos-x-csi/releases).  On
+the Releases page, right-click on the Helm Package and select "Copy
+Link Address".  Choose a namespace in which to run
+the driver (in this example, _seagate_), and a name for the
+application (_exos-x-csi_) and then paste the link the onto the end of
+this command.  For example: 
 ```
-  helm install seagate-csi -n seagate --create-namespace \
-    helm/csi-charts -f helm/csi-charts/values.yaml
+helm install --create-namespace -n seagate exos-x-csi <url-of-helm-package>
+```
+
+Alternately, you can download and unpack the [helm
+package](https://github.com/Seagate/seagate-exos-x-csi/releases/download/v1.6.3/seagate-exos-x-csi-1.6.3.tgz)
+and extract it:
+```
+wget https://github.com/Seagate/seagate-exos-x-csi/releases/download/v1.6.3/seagate-exos-x-csi-1.6.3.tgz
+tar xpzf seagate-exos-x-csi-1.6.3.tgz
+helm install --create-namespace -n seagate exos-x-csi seagate-exos-x-csi
+```
+or clone the Github repository and install from the helm/csi-charts folder:
+
+```
+git clone https://github.com/Seagate/seagate-exos-x-csi
+cd seagate-exos-x-csi
+helm install exos-x-csi -n seagate --create-namespace \
+  helm/csi-charts -f helm/csi-charts/values.yaml
 ```
 
 #### To deploy the provisioner to OpenShift cluster, run the following commands prior to using Helm:
 ```
-    oc create -f scc/exos-x-csi-access-scc.yaml --as system:admin
-    oc adm policy add-scc-to-user exos-x-csi-access -z default -n NAMESPACE
-    oc adm policy add-scc-to-user exos-x-csi-access -z csi-provisioner -n NAMESPACE
+oc create -f scc/exos-x-csi-access-scc.yaml --as system:admin
+oc adm policy add-scc-to-user exos-x-csi-access -z default -n NAMESPACE
+oc adm policy add-scc-to-user exos-x-csi-access -z csi-provisioner -n NAMESPACE
 ```
 
 #### Configure your release

--- a/helm/csi-charts/Chart.yaml
+++ b/helm/csi-charts/Chart.yaml
@@ -10,11 +10,14 @@ sources:
 keywords:
   - storage
   - iscsi
+  - fc
+  - sas
   - plugin
   - csi
 maintainers:
   - name: Seagate
     url: https://github.com/Seagate
+    email: css-host-software@seagate.com
   - name: Joe Skazinski
     email: joseph.skazinski@seagate.com
 annotations:

--- a/helm/csi-charts/values.yaml
+++ b/helm/csi-charts/values.yaml
@@ -6,16 +6,14 @@
 kubeletPath: /var/lib/kubelet
 # -- Wether psp admission controller has been enabled in the cluster or not
 pspAdmissionControllerEnabled: false
-
 image:
   # -- Docker repository to use for nodes and controller
   repository: ghcr.io/seagate/seagate-exos-x-csi
   # -- Tag to use for nodes and controller
   # @default -- Uses Chart.appVersion value by default if tag does not specify a new version.
-  tag: "v1.6.3" 
+  tag: "v1.6.3"
   # -- Default is set to IfNotPresent, to override use Always here to always pull the specified version
   pullPolicy: Always
-
 # -- Controller sidecar for provisioning
 # AKA external-provisioner
 csiProvisioner:
@@ -26,7 +24,6 @@ csiProvisioner:
   timeout: 30s
   # -- Extra arguments for csi-provisioner controller sidecar
   extraArgs: [--feature-gates=Topology=true]
-
 # -- Controller sidecar for attachment handling
 csiAttacher:
   image:
@@ -36,7 +33,6 @@ csiAttacher:
   timeout: 30s
   # -- Extra arguments for csi-attacher controller sidecar
   extraArgs: []
-
 # -- Controller sidecar for volume expansion
 csiResizer:
   image:
@@ -44,7 +40,6 @@ csiResizer:
     tag: v1.3.0
   # -- Extra arguments for csi-resizer controller sidecar
   extraArgs: []
-
 # -- Controller sidecar for snapshots handling
 csiSnapshotter:
   image:
@@ -52,7 +47,6 @@ csiSnapshotter:
     tag: v4.2.1
   # -- Extra arguments for csi-snapshotter controller sidecar
   extraArgs: []
-
 # -- Node sidecar for plugin registration
 csiNodeRegistrar:
   image:
@@ -60,19 +54,15 @@ csiNodeRegistrar:
     tag: v2.3.0
   # -- Extra arguments for csi-node-registrar node sidecar
   extraArgs: []
-
 controller:
   # -- Extra arguments for seagate-exos-x-csi-controller container
   extraArgs: [-v=0]
-
 node:
   # -- Extra arguments for seagate-exos-x-csi-node containers
   extraArgs: [-v=0]
-
 multipathd:
   # -- Extra arguments for multipathd containers
   extraArgs: []
-
 # -- Container that convert CSI liveness probe to kubernetes liveness/readiness probe
 nodeLivenessProbe:
   image:
@@ -80,18 +70,14 @@ nodeLivenessProbe:
     tag: v2.4.0
   # -- Extra arguments for the node's liveness probe containers
   extraArgs: []
-
 nodeServer:
   # -- Kubernetes nodeSelector field for seagate-exos-x-csi-node-server Pod
   nodeSelector:
   # -- Kubernetes nodeAffinity field for seagate-exos-x-csi-node-server Pod
   nodeAffinity:
-
 podMonitor:
   # -- Set a Prometheus operator PodMonitor resource (true or false)
   enabled: false
-
 serviceMonitor:
   # -- Set a Prometheus operator ServiceMonitor resource (true or false)
   enabled: false
-  


### PR DESCRIPTION
Added (more) support for automating the process of resubmitting the driver for Red Hat certification.

The Helm values.yaml file was run through yq to remove blank space, so future automated updates to the version number will not show so many changes to the file.

The README was updated to describe the method for installing the driver with a single command using a link to the helm package on the Github repo.