### PR TITLE
fix: default to iSCSI if no initiator type specified

### DIFF
--- a/pkg/node_service/node_service_server.go
+++ b/pkg/node_service/node_service_server.go
@@ -25,7 +25,8 @@ func (s *server) GetInitiators(ctx context.Context, in *pb.InitiatorRequest) (*p
 	case pb.InitiatorType_ISCSI:
 		initiators, err = storage.GetISCSIInitiators()
 	case pb.InitiatorType_UNSPECIFIED:
-		klog.InfoS("Unspecified initiator type in initiator request")
+		klog.InfoS("Unspecified initiator type in initiator request, defaulting to iSCSI")
+		initiators, err = storage.GetISCSIInitiators()
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously the driver defaulted to iSCSI if no protocol was specified, a holdover from being iSCSI only initially. This change restores that behavior for the new gRPC initiator retrieval service.