### PR TITLE
perf: Update node-controller rpc service to notify nodes on volume unmap

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -16,5 +16,7 @@ func main() {
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 	klog.Infof("starting storage controller (%s)", common.Version)
-	controller.New().Start(*bind)
+	c := controller.New()
+	defer c.Stop()
+	c.Start(*bind)
 }

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -25,5 +25,7 @@ func main() {
 	}
 
 	klog.Infof("starting storage node plugin (%s)", common.Version)
-	node.New().Start(*bind)
+	n := node.New()
+	defer n.Stop()
+	n.Start(*bind)
 }

--- a/pkg/common/driver.go
+++ b/pkg/common/driver.go
@@ -3,8 +3,6 @@ package common
 import (
 	"context"
 	"net"
-	"os"
-	"os/signal"
 	"runtime"
 	"strings"
 	"sync"
@@ -171,18 +169,6 @@ func (driver *Driver) Start(bind string) {
 		klog.Fatal(err)
 	}
 	driver.socket = socket
-
-	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT,
-	)
-	go func() {
-		_ = <-sigc
-		driver.Stop()
-	}()
 
 	go func() {
 		driver.exporter.ListenAndServe()

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -25,10 +25,11 @@ import (
 type Node struct {
 	*common.Driver
 
-	semaphore *semaphore.Weighted
-	runPath   string
-	nodeName  string
-	nodeIP    string
+	semaphore  *semaphore.Weighted
+	runPath    string
+	nodeName   string
+	nodeIP     string
+	nodeServer *grpc.Server
 }
 
 // New is a convenience function for creating a node driver
@@ -247,6 +248,12 @@ func (node *Node) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeR
 // getConnectorInfoPath
 func (node *Node) getConnectorInfoPath(storageProtocol, volumeID string) string {
 	return fmt.Sprintf("%s/%s-%s.json", node.runPath, storageProtocol, volumeID)
+}
+
+// Graceful shutdown of the node-controller RPC server
+func (node *Node) Stop() {
+	klog.V(3).InfoS("Controller code graceful shutdown..")
+	node.nodeServer.GracefulStop()
 }
 
 // checkHostBinary: Determine if a binary image is installed or not

--- a/pkg/node_service/node_service_client.go
+++ b/pkg/node_service/node_service_client.go
@@ -28,10 +28,10 @@ func InitializeClient(nodeAddress string) (conn *grpc.ClientConn, err error) {
 }
 
 // Connect to the node_service gRPC server at the given address and retrieve initiators
-func GetNodeInitiators(conn *grpc.ClientConn, reqType pb.InitiatorType) ([]string, error) {
+func GetNodeInitiators(ctx context.Context, conn *grpc.ClientConn, reqType pb.InitiatorType) ([]string, error) {
 	client := pb.NewNodeServiceClient(conn)
 	initiatorReq := pb.InitiatorRequest{Type: reqType}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	initiators, err := client.GetInitiators(ctx, &initiatorReq)
 	if err != nil {
@@ -41,14 +41,14 @@ func GetNodeInitiators(conn *grpc.ClientConn, reqType pb.InitiatorType) ([]strin
 	return initiators.Initiators, nil
 }
 
-func NotifyUnmap(conn *grpc.ClientConn, volumeName string) (err error) {
+func NotifyUnmap(ctx context.Context, conn *grpc.ClientConn, volumeName string) (err error) {
 	client := pb.NewNodeServiceClient(conn)
 	unmappedVolumePb := pb.UnmappedVolume{VolumeName: volumeName}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	_, err = client.NotifyUnmap(ctx, &unmappedVolumePb)
 	if err != nil {
-		klog.InfoS("Error during unmap notification", "unmappedVolumeName", volumeName)
+		klog.ErrorS(err, "Error during unmap notification", "unmappedVolumeName", volumeName)
 	}
 	return
 }

--- a/pkg/node_service/node_service_client.go
+++ b/pkg/node_service/node_service_client.go
@@ -12,31 +12,43 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// Connect to the node_service gRPC server at the given address and retrieve initiators
-func GetNodeInitiators(nodeAddress string, reqType pb.InitiatorType) ([]string, error) {
+func InitializeClient(nodeAddress string) (conn *grpc.ClientConn, err error) {
 	port, envFound := os.LookupEnv(common.NodeServicePortEnvVar)
 	if !envFound {
 		port = "978"
 		klog.InfoS("no node service port found in environment. using default", "port", port)
 	}
-
 	nodeServiceAddr := nodeAddress + ":" + port
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	conn, err := grpc.Dial(nodeServiceAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err = grpc.Dial(nodeServiceAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		klog.ErrorS(err, "Error connecting to node service", "node ip", nodeAddress, "port", port)
-		return nil, err
+		return
 	}
-	defer conn.Close()
+	return
+}
 
+// Connect to the node_service gRPC server at the given address and retrieve initiators
+func GetNodeInitiators(conn *grpc.ClientConn, reqType pb.InitiatorType) ([]string, error) {
 	client := pb.NewNodeServiceClient(conn)
 	initiatorReq := pb.InitiatorRequest{Type: reqType}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	initiators, err := client.GetInitiators(ctx, &initiatorReq)
 	if err != nil {
-		klog.ErrorS(err, "Error during GetInitiators", "initiatorReq", initiatorReq)
+		klog.ErrorS(err, "Error during GetInitiators", "reqType", initiatorReq.Type)
 		return nil, err
 	}
 	return initiators.Initiators, nil
+}
+
+func NotifyUnmap(conn *grpc.ClientConn, volumeName string) (err error) {
+	client := pb.NewNodeServiceClient(conn)
+	unmappedVolumePb := pb.UnmappedVolume{VolumeName: volumeName}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err = client.NotifyUnmap(ctx, &unmappedVolumePb)
+	if err != nil {
+		klog.InfoS("Error during unmap notification", "unmappedVolumeName", volumeName)
+	}
+	return
 }

--- a/pkg/node_service/node_service_server.go
+++ b/pkg/node_service/node_service_server.go
@@ -35,6 +35,8 @@ func (s *server) GetInitiators(ctx context.Context, in *pb.InitiatorRequest) (*p
 }
 
 func (s *server) NotifyUnmap(ctx context.Context, in *pb.UnmappedVolume) (*pb.Ack, error) {
+	delete(storage.GlobalRemovedDevicesMap, in.GetVolumeName())
+	klog.V(5).InfoS("Global unmapped device map deletion", "globalMap", storage.GlobalRemovedDevicesMap, "volumeName", in.GetVolumeName())
 	return &pb.Ack{Ack: 1}, nil
 }
 

--- a/pkg/node_service/node_service_server.go
+++ b/pkg/node_service/node_service_server.go
@@ -14,6 +14,7 @@ type server struct {
 	pb.UnimplementedNodeServiceServer
 }
 
+// Retrieve initiator addresses from the node
 func (s *server) GetInitiators(ctx context.Context, in *pb.InitiatorRequest) (*pb.Initiators, error) {
 	initiators := []string{}
 	var err error
@@ -34,18 +35,18 @@ func (s *server) GetInitiators(ctx context.Context, in *pb.InitiatorRequest) (*p
 	return &pb.Initiators{Initiators: initiators}, nil
 }
 
+// Notify node that a volume has been unmapped from the controller
 func (s *server) NotifyUnmap(ctx context.Context, in *pb.UnmappedVolume) (*pb.Ack, error) {
 	delete(storage.GlobalRemovedDevicesMap, in.GetVolumeName())
 	klog.V(5).InfoS("Global unmapped device map deletion", "globalMap", storage.GlobalRemovedDevicesMap, "volumeName", in.GetVolumeName())
 	return &pb.Ack{Ack: 1}, nil
 }
 
-func ListenAndServe(port string) {
+func ListenAndServe(s *grpc.Server, port string) {
 	lis, err := net.Listen("tcp", ":"+port)
 	if err != nil {
 		klog.ErrorS(err, "Node Service gRPC server failed to listen")
 	}
-	s := grpc.NewServer()
 	pb.RegisterNodeServiceServer(s, &server{})
 	klog.V(0).InfoS("Node Service gRPC server listening", "address", lis.Addr())
 	s.Serve(lis)

--- a/pkg/storage/fcNode.go
+++ b/pkg/storage/fcNode.go
@@ -84,7 +84,7 @@ func (fc *fcStorage) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	klog.Infof("attached device at %s", path)
 
 	// if current wwn has been published before, remove it from our list of previously unpublished wwns
-	delete(globalRemovedDevicesMap, wwn)
+	delete(GlobalRemovedDevicesMap, wwn)
 	// check if previously unpublished devices were rediscovered by the scsi subsystem during Attach
 	checkPreviouslyRemovedDevices(ctx)
 
@@ -242,7 +242,7 @@ func (fc *fcStorage) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpub
 	klog.Infof("deleting FC connection info file %s", fc.connectorInfoPath)
 	os.Remove(fc.connectorInfoPath)
 
-	globalRemovedDevicesMap[connector.VolumeWWN] = time.Now()
+	GlobalRemovedDevicesMap[connector.VolumeWWN] = time.Now()
 
 	klog.Info("successfully detached FC device")
 	return &csi.NodeUnpublishVolumeResponse{}, nil

--- a/pkg/storage/sasNode.go
+++ b/pkg/storage/sasNode.go
@@ -152,7 +152,7 @@ func (sas *sasStorage) NodePublishVolume(ctx context.Context, req *csi.NodePubli
 	klog.Infof("attached device at %s", path)
 
 	// if current wwn has been published before, remove it from our list of previously unpublished wwns
-	delete(globalRemovedDevicesMap, wwn)
+	delete(GlobalRemovedDevicesMap, wwn)
 	// check if previously unpublished devices were rediscovered by the scsi subsystem during Attach
 	checkPreviouslyRemovedDevices(ctx)
 
@@ -308,7 +308,7 @@ func (sas *sasStorage) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnp
 	klog.Infof("deleting SAS connection info file %s", sas.connectorInfoPath)
 	os.Remove(sas.connectorInfoPath)
 
-	globalRemovedDevicesMap[connector.VolumeWWN] = time.Now()
+	GlobalRemovedDevicesMap[connector.VolumeWWN] = time.Now()
 
 	klog.Info("successfully detached SAS device")
 	return &csi.NodeUnpublishVolumeResponse{}, nil
@@ -316,7 +316,7 @@ func (sas *sasStorage) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnp
 
 func checkPreviouslyRemovedDevices(ctx context.Context) error {
 	klog.Info("Checking previously removed devices")
-	for wwn := range globalRemovedDevicesMap {
+	for wwn := range GlobalRemovedDevicesMap {
 		klog.Infof("Checking for rediscovery of wwn:%s", wwn)
 
 		dm, devices := saslib.FindDiskById(klog.FromContext(ctx), wwn, &saslib.OSioHandler{})

--- a/pkg/storage/storageService.go
+++ b/pkg/storage/storageService.go
@@ -62,7 +62,7 @@ type sasStorage struct {
 }
 
 // Map of device WWNs to timestamp of when they were unpublished from the node
-var globalRemovedDevicesMap = map[string]time.Time{}
+var GlobalRemovedDevicesMap = map[string]time.Time{}
 
 // buildCommonService:
 func buildCommonService(config map[string]string) (commonService, error) {


### PR DESCRIPTION
Utilizing the node-controller RPC communication server, notify node after a volume has completed controller unmap, so that it can stop checking for device rediscovery.

Also adds re-use of the grpc.ClientConn objects for better performance, as well as graceful shutdown of grpc clients and servers