### PR TITLE
fix: Use ubi7 instead of ubi7/go-toolset for final image

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -26,11 +26,11 @@ RUN ls -l /
 
 ########################################################################
 
-FROM registry.access.redhat.com/ubi7/go-toolset:1.19
+FROM registry.access.redhat.com/ubi7
 
-ARG version=v1.7.2
-ARG vcs_ref=89c5c4558d77735c53f25d44789938f6dc609e62
-ARG build_date=2023-06-28T00:45:11+00:00
+ARG version=v1.7.3
+ARG vcs_ref=f64a389bd19c45ff31ce5026ea28f7ad3e954723
+ARG build_date=2023-07-20T14:37:39+00:00
 ARG vendor=Seagate
 ARG family="Exos X"
 ARG app="${family} CSI Driver"

--- a/helm/csi-charts/values.yaml
+++ b/helm/csi-charts/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: ghcr.io/seagate/seagate-exos-x-csi
   # -- Tag to use for nodes and controller
   # @default -- Uses Chart.appVersion value by default if tag does not specify a new version.
-  tag: "v1.7.2"
+  tag: "v1.7.3"
   # -- Default is set to IfNotPresent, to override use Always here to always pull the specified version
   pullPolicy: Always
 # -- Controller sidecar for provisioning


### PR DESCRIPTION
We don't need the go-toolset included in the final container image, use standard ubi7 as a base image instead. Additionally this release will trigger a build using the new version of the ubi7-go-toolset-1.19 container images which address several CVEs. See https://access.redhat.com/errata/RHSA-2023:3920 for details on the security fixes.