### PR TITLE
fix: Update csi-lib-iscsi and api-go to integrate bug fixes

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -28,7 +28,7 @@ RUN ls -l /
 
 FROM registry.access.redhat.com/ubi8
 
-ARG version=v1.8.3
+ARG version=v1.8.4
 ARG vcs_ref=1a46e346f0094ef80951e5c4c9ef315785b0e2c2
 ARG build_date=2023-10-13T20:52:10+00:00
 ARG vendor=Seagate

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 ifdef VERSION
 VERSION := $(VERSION)
 else
-VERSION := v1.8.3
+VERSION := v1.8.4
 endif
 HELM_VERSION := $(subst v,,$(VERSION))
 VERSION_FLAG = -X $(GITHUB_URL)/pkg/common.Version=$(VERSION)

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/Seagate/seagate-exos-x-csi
 go 1.20
 
 require (
-	github.com/Seagate/csi-lib-iscsi v1.0.3
+	github.com/Seagate/csi-lib-iscsi v1.1.0
 	github.com/Seagate/csi-lib-sas v1.0.2
-	github.com/Seagate/seagate-exos-x-api-go/v2 v2.0.3
+	github.com/Seagate/seagate-exos-x-api-go/v2 v2.1.0
 	github.com/container-storage-interface/spec v1.8.0
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,12 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Seagate/csi-lib-iscsi v1.0.3 h1:PEPCySqKmdRwgyM4vb/cugFVyNbo5JL+f/J7W4Q/WVw=
-github.com/Seagate/csi-lib-iscsi v1.0.3/go.mod h1:sp7ftl8BMVgMNybv3sw8V20MJsX0bl2w5BoSFlBRPkY=
+github.com/Seagate/csi-lib-iscsi v1.1.0 h1:2Kw5tqqyscpi7ewGi+g4oSLRVRbANLA1ZuEnjuEqR74=
+github.com/Seagate/csi-lib-iscsi v1.1.0/go.mod h1:sp7ftl8BMVgMNybv3sw8V20MJsX0bl2w5BoSFlBRPkY=
 github.com/Seagate/csi-lib-sas v1.0.2 h1:rR/tPmQMYt7nwor5YC1LInxrYvueLjCxFKHxkh0qL5A=
 github.com/Seagate/csi-lib-sas v1.0.2/go.mod h1:lX/OnO0sLm4vXCFwsPADyzZxSFkmXv5t+WleiYNkN8U=
-github.com/Seagate/seagate-exos-x-api-go/v2 v2.0.3 h1:ll/4O1OjieCPqiLX2cAnqNl+nI2yGvV2HfL87yN49UM=
-github.com/Seagate/seagate-exos-x-api-go/v2 v2.0.3/go.mod h1:ldU5jMQEpfOhPZlx1zYkDN7fIaFCGhD4ZB5GFQiYgvI=
+github.com/Seagate/seagate-exos-x-api-go/v2 v2.1.0 h1:WKZx43oRw5SD6WHA5jwoa6g0/J47EQFtgqKgLWhKLzY=
+github.com/Seagate/seagate-exos-x-api-go/v2 v2.1.0/go.mod h1:ldU5jMQEpfOhPZlx1zYkDN7fIaFCGhD4ZB5GFQiYgvI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/helm/csi-charts/values.yaml
+++ b/helm/csi-charts/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: ghcr.io/seagate/seagate-exos-x-csi
   # -- Tag to use for nodes and controller
   # @default -- Uses Chart.appVersion value by default if tag does not specify a new version.
-  tag: "v1.8.3"
+  tag: "v1.8.4"
   # -- Default is set to IfNotPresent, to override use Always here to always pull the specified version
   pullPolicy: Always
 # -- Controller sidecar for provisioning


### PR DESCRIPTION
Update to latest versions of csi-lib-iscsi and api-go modules. The new csi-lib-iscsi has a reworked iscsi rescan method to prevent a possible device discovery race condition. The api-go update includes a bug fix for LUN selection. Update version numbers to 1.8.4 for release.