### PR TITLE
chore: Update for api lib 2.2.0 create volume change

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -28,9 +28,9 @@ RUN ls -l /
 
 FROM registry.access.redhat.com/ubi8
 
-ARG version=v1.8.4
-ARG vcs_ref=1a46e346f0094ef80951e5c4c9ef315785b0e2c2
-ARG build_date=2023-10-13T20:52:10+00:00
+ARG version=v1.8.5
+ARG vcs_ref=e8ce79173c18f52e1495a9bdf10bc72cb1e88f03
+ARG build_date=2024-02-16T22:09:11+00:00
 ARG vendor=Seagate
 ARG family="Exos X"
 ARG app="${family} CSI Driver"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 ifdef VERSION
 VERSION := $(VERSION)
 else
-VERSION := v1.8.4
+VERSION := v1.8.5
 endif
 HELM_VERSION := $(subst v,,$(VERSION))
 VERSION_FLAG = -X $(GITHUB_URL)/pkg/common.Version=$(VERSION)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Seagate/csi-lib-iscsi v1.1.0
 	github.com/Seagate/csi-lib-sas v1.0.2
-	github.com/Seagate/seagate-exos-x-api-go/v2 v2.1.0
+	github.com/Seagate/seagate-exos-x-api-go/v2 v2.2.0
 	github.com/container-storage-interface/spec v1.8.0
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Seagate/csi-lib-iscsi v1.1.0 h1:2Kw5tqqyscpi7ewGi+g4oSLRVRbANLA1ZuEnj
 github.com/Seagate/csi-lib-iscsi v1.1.0/go.mod h1:sp7ftl8BMVgMNybv3sw8V20MJsX0bl2w5BoSFlBRPkY=
 github.com/Seagate/csi-lib-sas v1.0.2 h1:rR/tPmQMYt7nwor5YC1LInxrYvueLjCxFKHxkh0qL5A=
 github.com/Seagate/csi-lib-sas v1.0.2/go.mod h1:lX/OnO0sLm4vXCFwsPADyzZxSFkmXv5t+WleiYNkN8U=
-github.com/Seagate/seagate-exos-x-api-go/v2 v2.1.0 h1:WKZx43oRw5SD6WHA5jwoa6g0/J47EQFtgqKgLWhKLzY=
-github.com/Seagate/seagate-exos-x-api-go/v2 v2.1.0/go.mod h1:ldU5jMQEpfOhPZlx1zYkDN7fIaFCGhD4ZB5GFQiYgvI=
+github.com/Seagate/seagate-exos-x-api-go/v2 v2.2.0 h1:dFd0Oqpzg1s2vU0FDs+a4aMYtGnwl7tQVqqDu9Gzt3I=
+github.com/Seagate/seagate-exos-x-api-go/v2 v2.2.0/go.mod h1:ldU5jMQEpfOhPZlx1zYkDN7fIaFCGhD4ZB5GFQiYgvI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/helm/csi-charts/values.yaml
+++ b/helm/csi-charts/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: ghcr.io/seagate/seagate-exos-x-csi
   # -- Tag to use for nodes and controller
   # @default -- Uses Chart.appVersion value by default if tag does not specify a new version.
-  tag: "v1.8.4"
+  tag: "v1.8.5"
   # -- Default is set to IfNotPresent, to override use Always here to always pull the specified version
   pullPolicy: Always
 # -- Controller sidecar for provisioning

--- a/pkg/controller/provisioner.go
+++ b/pkg/controller/provisioner.go
@@ -75,14 +75,9 @@ func (controller *Controller) CreateVolume(ctx context.Context, req *csi.CreateV
 	size := req.GetCapacityRange().GetRequiredBytes()
 	sizeStr := getSizeStr(size)
 	pool := parameters[common.PoolConfigKey]
-	poolType, _ := controller.client.GetPoolType(pool)
 	wwn := ""
 
-	if len(poolType) == 0 {
-		poolType = "Virtual"
-	}
-
-	klog.Infof("creating volume %q (size %s) pool %q [%s] using protocol (%s)", volumeName, sizeStr, pool, poolType, storageProtocol)
+	klog.Infof("creating volume %q (size %s) pool %q using protocol (%s)", volumeName, sizeStr, pool, storageProtocol)
 
 	volumeExists, err := controller.client.CheckVolumeExists(volumeName, size)
 	if err != nil {
@@ -118,7 +113,7 @@ func (controller *Controller) CreateVolume(ctx context.Context, req *csi.CreateV
 			}
 
 		} else {
-			volume, _, err2 := controller.client.CreateVolume(volumeName, sizeStr, parameters[common.PoolConfigKey], poolType)
+			volume, _, err2 := controller.client.CreateVolume(volumeName, sizeStr, parameters[common.PoolConfigKey])
 			if err2 != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Integrates exos API Lib update 2.2.0 to omit the tier-affinity parameter from Create Volume calls, resolving a compatibility issue with linear storage pools.