### PR TITLE
Add multi-node block attach for live migration

### DIFF
--- a/pkg/common/driver.go
+++ b/pkg/common/driver.go
@@ -57,9 +57,10 @@ const (
 	NodeServicePortEnvVar = "CSI_NODE_SERVICE_PORT"
 )
 
-var SupportedAccessModes = [2]csi.VolumeCapability_AccessMode_Mode{
+var SupportedAccessModes = [3]csi.VolumeCapability_AccessMode_Mode{
 	csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 	csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
+	csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 }
 
 // Driver contains main resources needed by the driver and references the underlying specific driver

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -167,8 +167,8 @@ func (controller *Controller) ValidateVolumeCapabilities(ctx context.Context, re
 	if len(volumeName) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "cannot validate volume with empty ID")
 	}
-	if len(req.GetVolumeCapabilities()) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "cannot validate volume without capabilities")
+	if err := validateAccessModes(req.GetVolumeCapabilities()); err != nil {
+		return nil, err
 	}
 	_, _, err := controller.client.ShowVolumes(volumeName)
 	if err != nil {
@@ -272,6 +272,27 @@ func (controller *Controller) configureClient(credentials map[string]string) err
 	return err
 }
 
+func validateAccessModes(capabilities []*csi.VolumeCapability) error {
+	if len(capabilities) == 0 {
+		return status.Error(codes.InvalidArgument, "missing volume capabilities")
+	}
+
+	for _, capability := range capabilities {
+		accessMode := capability.GetAccessMode().GetMode()
+		accessModeSupported := false
+		for _, mode := range common.SupportedAccessModes {
+			if accessMode == mode {
+				accessModeSupported = true
+			}
+		}
+		if !accessModeSupported {
+			return status.Errorf(codes.FailedPrecondition, "driver does not support access mode %v", accessMode)
+		}
+	}
+
+	return nil
+}
+
 func runPreflightChecks(parameters map[string]string, capabilities *[]*csi.VolumeCapability) error {
 	checkIfKeyExistsInConfig := func(key string) error {
 		if parameters == nil {
@@ -291,20 +312,10 @@ func runPreflightChecks(parameters map[string]string, capabilities *[]*csi.Volum
 	}
 
 	if capabilities != nil {
-		if len(*capabilities) == 0 {
-			return status.Error(codes.InvalidArgument, "missing volume capabilities")
+		if err := validateAccessModes(*capabilities); err != nil {
+			return err
 		}
 		for _, capability := range *capabilities {
-			accessMode := capability.GetAccessMode().GetMode()
-			accessModeSupported := false
-			for _, mode := range common.SupportedAccessModes {
-				if accessMode == mode {
-					accessModeSupported = true
-				}
-			}
-			if !accessModeSupported {
-				return status.Errorf(codes.FailedPrecondition, "driver does not support access mode %v", accessMode)
-			}
 			if mount := capability.GetMount(); mount != nil {
 				if mount.GetFsType() == "" {
 					if err := checkIfKeyExistsInConfig(common.FsTypeConfigKey); err != nil {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Seagate/seagate-exos-x-csi/pkg/common"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func mountCapability(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability {
+	return &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+		AccessMode: &csi.VolumeCapability_AccessMode{Mode: mode},
+	}
+}
+
+func blockCapability(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability {
+	return &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Block{Block: &csi.VolumeCapability_BlockVolume{}},
+		AccessMode: &csi.VolumeCapability_AccessMode{Mode: mode},
+	}
+}
+
+func TestValidateAccessModesAcceptsSingleNodeWriterAndLiveMigrationBlockAttach(t *testing.T) {
+	caps := []*csi.VolumeCapability{
+		mountCapability(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+		blockCapability(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER),
+	}
+
+	if err := validateAccessModes(caps); err != nil {
+		t.Fatalf("validateAccessModes returned error for SINGLE_NODE_WRITER and live-migration block attach modes: %v", err)
+	}
+}
+
+func TestIsValidVolumeCapabilitiesRejectsUnsupportedMultiNodeMode(t *testing.T) {
+	caps := []*csi.VolumeCapability{
+		mountCapability(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
+	}
+
+	err := isValidVolumeCapabilities(caps)
+	if err == nil {
+		t.Fatal("expected unsupported multi-node access mode to be rejected")
+	}
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition, got %v", status.Code(err))
+	}
+}
+
+func TestValidateVolumeCapabilitiesRejectsUnsupportedMultiNodeModeBeforeLookup(t *testing.T) {
+	controller := &Controller{}
+	req := &csi.ValidateVolumeCapabilitiesRequest{
+		VolumeId:           common.VolumeIdAugment("vol-1", common.StorageProtocolISCSI, "wwn-1"),
+		VolumeCapabilities: []*csi.VolumeCapability{mountCapability(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY)},
+	}
+
+	_, err := controller.ValidateVolumeCapabilities(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected unsupported multi-node access mode to be rejected")
+	}
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition, got %v", status.Code(err))
+	}
+}

--- a/pkg/controller/provisioner.go
+++ b/pkg/controller/provisioner.go
@@ -200,24 +200,5 @@ func getSizeStr(size int64) string {
 
 // isValidVolumeCapabilities validates the given VolumeCapability array is valid
 func isValidVolumeCapabilities(volCaps []*csi.VolumeCapability) error {
-	if len(volCaps) == 0 {
-		return fmt.Errorf("volume capabilities to validate not provided")
-	}
-
-	hasSupport := func(cap *csi.VolumeCapability) bool {
-		for _, supportedMode := range common.SupportedAccessModes {
-			// we currently support block and mount volumes with both supported access modes, so don't check mount types
-			if cap.GetAccessMode().Mode == supportedMode {
-				return true
-			}
-		}
-		return false
-	}
-
-	for _, c := range volCaps {
-		if !hasSupport(c) {
-			return fmt.Errorf("driver does not support access mode %v", c.GetAccessMode())
-		}
-	}
-	return nil
+	return validateAccessModes(volCaps)
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -162,6 +162,23 @@ func (node *Node) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapab
 	return &csi.NodeGetCapabilitiesResponse{Capabilities: csc}, nil
 }
 
+// validateNodePublishVolumeCapability enforces the live-migration policy for multi-node block attach.
+func validateNodePublishVolumeCapability(capability *csi.VolumeCapability) error {
+	if capability == nil {
+		return status.Error(codes.InvalidArgument, "cannot publish volume without capabilities")
+	}
+	if capability.GetBlock() != nil && capability.GetMount() != nil {
+		return status.Error(codes.InvalidArgument, "cannot have both block and mount access type")
+	}
+	if capability.GetBlock() == nil && capability.GetMount() == nil {
+		return status.Error(codes.InvalidArgument, "volume access type not specified, must be either block or mount")
+	}
+	if capability.GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER && capability.GetMount() != nil {
+		return status.Error(codes.FailedPrecondition, "MULTI_NODE_MULTI_WRITER is only supported for multi-node block attach during live migration")
+	}
+	return nil
+}
+
 // NodePublishVolume mounts the device to the target path
 func (node *Node) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	if len(req.GetVolumeId()) == 0 {
@@ -170,16 +187,8 @@ func (node *Node) NodePublishVolume(ctx context.Context, req *csi.NodePublishVol
 	if len(req.GetTargetPath()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "cannot publish volume at an empty path")
 	}
-	if req.GetVolumeCapability() == nil {
-		return nil, status.Error(codes.InvalidArgument, "cannot publish volume without capabilities")
-	}
-	if req.GetVolumeCapability().GetBlock() != nil &&
-		req.GetVolumeCapability().GetMount() != nil {
-		return nil, status.Error(codes.InvalidArgument, "cannot have both block and mount access type")
-	}
-	if req.GetVolumeCapability().GetBlock() == nil &&
-		req.GetVolumeCapability().GetMount() == nil {
-		return nil, status.Error(codes.InvalidArgument, "volume access type not specified, must be either block or mount")
+	if err := validateNodePublishVolumeCapability(req.GetVolumeCapability()); err != nil {
+		return nil, err
 	}
 	// Extract the volume name and the storage protocol from the augmented volume id
 	volumeName, _ := common.VolumeIdGetName(req.GetVolumeId())

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1,0 +1,45 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func mountCapability(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability {
+	return &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+		AccessMode: &csi.VolumeCapability_AccessMode{Mode: mode},
+	}
+}
+
+func blockCapability(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability {
+	return &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Block{Block: &csi.VolumeCapability_BlockVolume{}},
+		AccessMode: &csi.VolumeCapability_AccessMode{Mode: mode},
+	}
+}
+
+func TestValidateNodePublishVolumeCapabilityAllowsSingleNodeWriterMount(t *testing.T) {
+	if err := validateNodePublishVolumeCapability(mountCapability(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER)); err != nil {
+		t.Fatalf("expected SINGLE_NODE_WRITER mount to be allowed: %v", err)
+	}
+}
+
+func TestValidateNodePublishVolumeCapabilityAllowsLiveMigrationMultiNodeBlockAttach(t *testing.T) {
+	if err := validateNodePublishVolumeCapability(blockCapability(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER)); err != nil {
+		t.Fatalf("expected live-migration multi-node block attach to be allowed: %v", err)
+	}
+}
+
+func TestValidateNodePublishVolumeCapabilityRejectsLiveMigrationMountVolume(t *testing.T) {
+	err := validateNodePublishVolumeCapability(mountCapability(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER))
+	if err == nil {
+		t.Fatal("expected live-migration multi-node mount volume to be rejected")
+	}
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition, got %v", status.Code(err))
+	}
+}


### PR DESCRIPTION
## Summary
This change adds support for multi-node block attach (RWX for block volumes) in the CSI driver, enabling compatibility with KubeVirt live migration.

## Problem
The CSI driver did not support creating volumes for live migration scenarios that require multi-node block attach. As a result, those volumes could not be provisioned with the needed access mode.

## Solution
Add support for MULTI_NODE_MULTI_WRITER for block volumes, and update controller and node validation to allow that access mode while continuing to reject it for mount volumes.


## Testing
- Created multiple VMs using multi-node block volumes
- Verified successful live migration between nodes
- Tested concurrent attachment of the same volume across nodes
- Performed node drain and confirmed workloads remain available
- Stress-tested with multiple volumes per VM (20+)

## Notes
Tested on OpenShift with KubeVirt using Dell ME5 storage backend.
MULTI_NODE_MULTI_WRITER is restricted to block volumes to align with CSI expectations and avoid unsafe shared filesystem usage.